### PR TITLE
Add a check for the target branch of submissions

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -35,8 +35,8 @@ jobs:
     steps:
     - name: Check target branch
       run: |
-        echo "Target branch: ${GITHUB_HEAD_REF}"
-        test "${GITHUB_HEAD_REF}" != "main"
+        echo "Target branch: ${GITHUB_BASE_REF}"
+        test "${GITHUB_BASE_REF}" != "main"
       if: >-
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.fork

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -30,6 +30,17 @@ jobs:
           echo "Error: submissions must only contain *.pbtxt files" && \
           exit 1 || true
 
+  check_target_branch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check target branch
+      run: |
+        echo "Target branch: ${GITHUB_HEAD_REF}"
+        test "${GITHUB_HEAD_REF}" != "main"
+      if: >-
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork
+
   process_submission:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Submissions should be merged into new branches rather than `main`. This check won't be marked as "required" since it will flag non-submission PRs as well.