### PR TITLE
Allow .pb files on PRs from local branches

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -33,15 +33,15 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.fork
     - name: Check changed files (PR from branch)
-        run: |
-          cd "${GITHUB_WORKSPACE}"
-          git diff --name-only upstream/main > changed_files.txt
-          grep -vE '\.pbtxt|\.pb$' changed_files.txt && \
-            echo "Error: submissions must only contain *.pbtxt files" && \
-            exit 1 || true
-        if: >-
-          github.event_name == 'pull_request' &&
-          ! github.event.pull_request.head.repo.fork
+      run: |
+        cd "${GITHUB_WORKSPACE}"
+        git diff --name-only upstream/main > changed_files.txt
+        grep -vE '\.pbtxt|\.pb$' changed_files.txt && \
+          echo "Error: submissions must only contain *.pbtxt files" && \
+          exit 1 || true
+      if: >-
+        github.event_name == 'pull_request' &&
+        ! github.event.pull_request.head.repo.fork
 
 
   check_target_branch:

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -22,13 +22,27 @@ jobs:
         echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
         git fetch --no-tags --prune --depth=1 upstream \
           +refs/heads/*:refs/remotes/upstream/*
-    - name: Check changed files
+    - name: Check changed files (PR from fork)
       run: |
         cd "${GITHUB_WORKSPACE}"
         git diff --name-only upstream/main > changed_files.txt
         grep -vE '\.pbtxt$' changed_files.txt && \
           echo "Error: submissions must only contain *.pbtxt files" && \
           exit 1 || true
+      if: >-
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork
+    - name: Check changed files (PR from branch)
+        run: |
+          cd "${GITHUB_WORKSPACE}"
+          git diff --name-only upstream/main > changed_files.txt
+          grep -vE '\.pbtxt|\.pb$' changed_files.txt && \
+            echo "Error: submissions must only contain *.pbtxt files" && \
+            exit 1 || true
+        if: >-
+          github.event_name == 'pull_request' &&
+          ! github.event.pull_request.head.repo.fork
+
 
   check_target_branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Will reduce the noise from failing tests when merging ORD submissions into main.