### PR TITLE
Set explicit ord-schema version for ord-data actions

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -10,7 +10,7 @@ name: Submission
 on: [pull_request, push]
 
 env:
-  ORD_SCHEMA_TAG=v0.1.1
+  ORD_SCHEMA_TAG: v0.1.1
 
 jobs:
   count_reactions:

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: Open-Reaction-Database/ord-schema
-        ref: env.ORD_SCHEMA_TAG
+        ref: ${{ env.ORD_SCHEMA_TAG }}
         path: ord-schema
     - name: Install miniconda
       uses: s-weigand/setup-conda@v1
@@ -119,7 +119,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: Open-Reaction-Database/ord-schema
-        ref: env.ORD_SCHEMA_TAG
+        ref: ${{ env.ORD_SCHEMA_TAG }}
         path: ord-schema
     - name: Identify changed files
       # NOTE(kearnes): This sets the NUM_CHANGED_FILES variable.

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -9,6 +9,9 @@ name: Submission
 
 on: [pull_request, push]
 
+env:
+  ORD_SCHEMA_TAG=v0.1.1
+
 jobs:
   count_reactions:
     if: >-
@@ -25,6 +28,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: Open-Reaction-Database/ord-schema
+        ref: env.ORD_SCHEMA_TAG
         path: ord-schema
     - name: Install miniconda
       uses: s-weigand/setup-conda@v1
@@ -115,6 +119,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: Open-Reaction-Database/ord-schema
+        ref: env.ORD_SCHEMA_TAG
         path: ord-schema
     - name: Identify changed files
       # NOTE(kearnes): This sets the NUM_CHANGED_FILES variable.

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: Open-Reaction-Database/ord-schema
-        ref: env.ORD_SCHEMA_TAG
+        ref: ${{ env.ORD_SCHEMA_TAG }}
         path: ord-schema
     - name: Install miniconda
       uses: s-weigand/setup-conda@v1

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/validation.yml'
 
 env:
-  ORD_SCHEMA_TAG=v0.1.1
+  ORD_SCHEMA_TAG: v0.1.1
 
 jobs:
   validate_database:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,6 +14,9 @@ on:
       # Runs when this file is modified in a PR.
       - '.github/workflows/validation.yml'
 
+env:
+  ORD_SCHEMA_TAG=v0.1.1
+
 jobs:
   validate_database:
     runs-on: ubuntu-latest
@@ -24,6 +27,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: Open-Reaction-Database/ord-schema
+        ref: env.ORD_SCHEMA_TAG
         path: ord-schema
     - name: Install miniconda
       uses: s-weigand/setup-conda@v1


### PR DESCRIPTION
Like we do in ord-editor, this allows for versioned actions so changes in ord-schema don't break everything.