### PR TITLE
Flow dataset from https://pubs.acs.org/doi/full/10.1021/co400012m

### DIFF
--- a/dataset.pbtxt
+++ b/dataset.pbtxt
@@ -1,0 +1,14082 @@
+name: "39 compound library from \"Building a Sulfonamide Library by Eco-Friendly Flow Synthesis\""
+description: "Library generated in DOI\302\24010.1021/co400012m (Table 2)"
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=C(OC)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "COc1ccc(NS(=O)(=O)c2ccc(C)cc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 92.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 98.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "IC1=CC=C(N)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)Nc2ccc(I)cc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 62.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 90.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)Nc2ccccc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 97.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1C(O)=O"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)Nc2ccccc2C(=O)O)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 70.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 86.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1C2=CC=CC=C2"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)Nc2ccccc2-c2ccccc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 89.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 98.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "N"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(N)(=O)=O)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 98.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NCC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)NCc2ccccc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 94.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NCC(O)=O"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)NCC(=O)O)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 86.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 98.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NCCCN(C)C"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)NCCCN(C)C)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 77.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 92.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+  reaction_id: "Reaction 8"
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC(CCC)C"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCC(C)NS(=O)(=O)c1ccc(C)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 97.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1CC1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)NC2CC2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 87.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 98.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CNC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)N(C)c2ccccc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 85.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 95.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "C1CNCCO1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)N2CCOCC2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 93.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "C12=CC=CC=C1CCN2"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)N2CCc3ccccc32)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 90.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 96.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "C12=CC=CC=C1CCCN2"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(S(=O)(=O)N2CCCc3ccccc32)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 95.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=S(C1=CC=C([N+]([O-])=O)C=C1)(Cl)=O"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "O=[N+]([O-])c1ccc(S(=O)(=O)Nc2ccccc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 88.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 98.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1C(O)=O"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=S(C1=CC=C([N+]([O-])=O)C=C1)(Cl)=O"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "O=C(O)c1ccccc1NS(=O)(=O)c1ccc([N+](=O)[O-])cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 60.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 89.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1C(C)C"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=S(C1=CC=C([N+]([O-])=O)C=C1)(Cl)=O"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CC(C)c1ccccc1NS(=O)(=O)c1ccc([N+](=O)[O-])cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 84.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 93.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NCC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=S(C1=CC=C([N+]([O-])=O)C=C1)(Cl)=O"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "O=[N+]([O-])c1ccc(S(=O)(=O)NCc2ccccc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 97.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NCC(OCC)=O"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=S(C1=CC=C([N+]([O-])=O)C=C1)(Cl)=O"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCOC(=O)CNS(=O)(=O)c1ccc([N+](=O)[O-])cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 90.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 97.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1CC1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=S(C1=CC=C([N+]([O-])=O)C=C1)(Cl)=O"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "O=[N+]([O-])c1ccc(S(=O)(=O)NC2CC2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 82.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 93.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=C(OC)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=C(C)C1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "COc1ccc(NS(=O)(=O)c2ccc(C(C)=O)cc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 96.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "IC1=CC=C(N)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=C(C)C1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CC(=O)c1ccc(S(=O)(=O)Nc2ccc(I)cc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 68.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 91.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=C(C)C1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CC(=O)c1ccc(S(=O)(=O)Nc2ccccc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 82.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 98.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NCC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=C(C)C1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CC(=O)c1ccc(S(=O)(=O)NCc2ccccc2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 98.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NCC(OCC)=O"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=C(C)C1=CC=C(S(=O)(Cl)=O)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCOC(=O)CNS(=O)(=O)c1ccc(C(C)=O)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 78.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 93.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "COC1=CC=C(S(=O)(Cl)=O)C=C1OC"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "COc1ccc(S(=O)(=O)Nc2ccccc2)cc1OC"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 96.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1C(O)=O"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "COC1=CC=C(S(=O)(Cl)=O)C=C1OC"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "COc1ccc(S(=O)(=O)Nc2ccccc2C(=O)O)cc1OC"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 58.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 85.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1C(C)C"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "COC1=CC=C(S(=O)(Cl)=O)C=C1OC"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "COc1ccc(S(=O)(=O)Nc2ccccc2C(C)C)cc1OC"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 96.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NCC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "COC1=CC=C(S(=O)(Cl)=O)C=C1OC"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "COc1ccc(S(=O)(=O)NCc2ccccc2)cc1OC"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 97.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NCCCC(OC)=O"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "COC1=CC=C(S(=O)(Cl)=O)C=C1OC"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "COC(=O)CCCNS(=O)(=O)c1ccc(OC)c(OC)c1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 80.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 90.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC(CCC)C"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC(C)=C(S(=O)(Cl)=O)C(C)=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCC(C)NS(=O)(=O)c1c(C)cc(C)cc1C"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 76.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 85.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "C1CNCCO1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC(C)=C(S(=O)(Cl)=O)C(C)=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1cc(C)c(S(=O)(=O)N2CCOCC2)c(C)c1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 82.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 95.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=CC=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC(C)=C(S(=O)(Cl)=O)C(C)=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1cc(C)c(S(=O)(=O)Nc2ccccc2)c(C)c1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 83.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "NC1=CC=C(OC)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC(C)=C(S(=O)(Cl)=O)C(C)=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "COc1ccc(NS(=O)(=O)c2c(C)cc(C)cc2C)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 87.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 100.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "IC1=CC=C(N)C=C1"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC(C)=C(S(=O)(Cl)=O)C(C)=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1cc(C)c(S(=O)(=O)Nc2ccc(I)cc2)c(C)c1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 72.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 98.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "C12=CC=CC=C1CCN2"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC(C)=C(S(=O)(Cl)=O)C(C)=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1cc(C)c(S(=O)(=O)N2CCc3ccccc32)c(C)c1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 81.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 88.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "C12=CC=CC=C1CCCN2"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC(C)=C(S(=O)(Cl)=O)C(C)=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1cc(C)c(S(=O)(=O)N2CCCc3ccccc32)c(C)c1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 71.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 86.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}
+reactions {
+  inputs {
+    key: "amine and nahco3 in h2o/peg"
+    value {
+      components {
+        identifiers {
+          type: NAME
+          value: "NaHCO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])O.[Na+]"
+        }
+        amount {
+          moles {
+            value: 0.4
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=C(OCC1=CC=CC=C1)C2NCCC2"
+        }
+        amount {
+          moles {
+            value: 0.22
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: false
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "PEG400"
+        }
+        identifiers {
+          type: SMILES
+          details: "NAME resolved by the PubChem API"
+          value: "OCCOCCOCCOCCOCCO"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  inputs {
+    key: "sulfonyl chloride in acetone"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1=CC(C)=C(S(=O)(Cl)=O)C(C)=C1"
+        }
+        amount {
+          moles {
+            value: 0.2
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+        is_limiting: true
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "acetone"
+        }
+        identifiers {
+          type: SMILES
+          value: "CC(C)=O"
+        }
+        amount {
+          volume {
+            value: 2.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      flow_rate {
+        value: 0.25
+        units: MILLILITER_PER_MINUTE
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: TUBE
+      material {
+        type: PLASTIC
+        details: "PTFE"
+      }
+      attachments {
+        type: PRESSURE_REGULATOR
+        details: "back pressure regulator"
+      }
+      volume {
+        value: 10.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: CUSTOM
+        details: "\"warmed\""
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      control {
+        type: PRESSURIZED
+        details: "back pressure regulator"
+      }
+      setpoint {
+        value: 100.0
+        units: PSI
+      }
+    }
+    flow {
+      type: PLUG_FLOW_REACTOR
+      tubing {
+        type: PTFE
+      }
+    }
+  }
+  workups {
+    type: ADDITION
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Et2O"
+        }
+        identifiers {
+          type: SMILES
+          value: "CCOCC"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "HCl"
+        }
+        identifiers {
+          type: SMILES
+          value: "Cl"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: WORKUP
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: EXTRACTION
+    keep_phase: "organic"
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+      }
+    }
+  }
+  workups {
+    type: WASH
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O"
+        }
+        amount {
+          volume {
+            value: 1.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: WORKUP
+      }
+    }
+  }
+  workups {
+    type: DRY_WITH_MATERIAL
+    input {
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2SO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)([O-])[O-].[Na+].[Na+]"
+        }
+      }
+    }
+  }
+  workups {
+    type: CONCENTRATION
+  }
+  outcomes {
+    reaction_time {
+      value: 20.0
+      units: MINUTE
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1cc(C)c(S(=O)(=O)N2CCCC2C(=O)OCc2ccccc2)c(C)c1"
+      }
+      is_desired_product: true
+      measurements {
+        analysis_key: "isolated weight"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 76.0
+        }
+      }
+      measurements {
+        analysis_key: "crude nmr"
+        type: YIELD
+        is_normalized: true
+        percentage {
+          value: 90.0
+        }
+      }
+      reaction_role: PRODUCT
+    }
+    analyses {
+      key: "crude nmr"
+      value {
+        type: NMR_1H
+        details: "NMR of crude reaction mixture before workup"
+        is_of_isolated_species: false
+        instrument_manufacturer: "Bruker"
+      }
+    }
+    analyses {
+      key: "gcms"
+      value {
+        type: GCMS
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "isolated weight"
+      value {
+        type: WEIGHT
+        is_of_isolated_species: true
+      }
+    }
+    analyses {
+      key: "nmr of pure"
+      value {
+        type: NMR_1H
+        is_of_isolated_species: true
+      }
+    }
+  }
+  provenance {
+    experimenter {
+      organization: "Universit\303\240 di Perugia"
+    }
+    doi: "10.1021/co400012m"
+    publication_url: "https://pubs.acs.org/doi/full/10.1021/co400012m"
+    record_created {
+      time {
+        value: "6/26/2021, 4:31:37 PM"
+      }
+      person {
+        name: "Connor W. Coley"
+        orcid: "0000-0002-8271-8723"
+        organization: "MIT"
+        email: "ccoley@mit.edu"
+      }
+    }
+  }
+}


### PR DESCRIPTION
39 reaction library listed in Table 2. Details are rather sparse, but this is a nice library generated in flow through a single-step reaction.

Template reaction made using the online editor & manually changing yield entries to be placeholders. Excel sheet with all reactants (mols drawn in Chemdraw) and yields. Short script used to enumerate product SMILES. 

Note that there is more detail in the paper on product outcomes (states, colors, analytical data for isolated products) than I've copied. The two performance metrics I focused on were those in Table 2: crude NMR yield and isolated yield after workup. We're missing details about the pump type, reactor tube diameter, and how it was warmed. But this at least uses the addition flowrate yield and flow condition details.

[Archive.zip](https://github.com/open-reaction-database/ord-data/files/6720705/Archive.zip)
