### PR TITLE
Change 4 names/descriptions to remove blank entries

### DIFF
--- a/data/3b/ord_dataset-3b5db90e337942ea886b8f5bc5e3aa72.pb.gz
+++ b/data/3b/ord_dataset-3b5db90e337942ea886b8f5bc5e3aa72.pb.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64fd4cde7eaa7319664466c6681eb651e0baf2d786e76fb1522761d01c74f9d6
-size 36926
+oid sha256:598aea3c14f303e8d2c3315c1389a27ab62959aecdb536ebee3e5f755a1076dd
+size 37034

--- a/data/68/ord_dataset-68cb8b4b2b384e3d85b5b1efae58b203.pb.gz
+++ b/data/68/ord_dataset-68cb8b4b2b384e3d85b5b1efae58b203.pb.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42a32b68464e262c30b4e4fd11fc885e62ae31a8bbea5df4214a7df76268d426
-size 269557
+oid sha256:0cbcf613395e9bab0bd274f0ae81a73f4b230fbba557e4cf477d024407dcf8af
+size 269731

--- a/data/cb/ord_dataset-cbcc4048add7468e850b6ec42549c70d.pb.gz
+++ b/data/cb/ord_dataset-cbcc4048add7468e850b6ec42549c70d.pb.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9412b601819f38cfafa9dfaaca3883284c8a00a01ea5c16b056fdc6d6a6a229b
-size 18770
+oid sha256:2e607037dfec6904e0e3a73ba39f1a72c96a24f92d9d3b3c219ad47c52b91db3
+size 18864

--- a/data/ee/ord_dataset-eeba974d3c284aed86d1c1d442260a1e.pb.gz
+++ b/data/ee/ord_dataset-eeba974d3c284aed86d1c1d442260a1e.pb.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9c046ae452804e2bc18b388b4cc3c7af11fe541036763d1908335912687f6b3
-size 25337
+oid sha256:783e0a7d68fa160e93730a3a9c3ecf343e8f86f1d0d4e6f3617726ff22aa9f89
+size 25393


### PR DESCRIPTION
Received information from original dataset authors with suggested names/descriptions. Modified via short script

```
import os
from ord_schema import message_helpers
from ord_schemam.proto import dataset_pb2
from google.protobuf import json_format

dsets = [
    ("ord_dataset-68cb8b4b2b384e3d85b5b1efae58b203",
    "Rapid material-sparing screening of 5760 Suzuki-Miyaura coupling reactions",
    "5760 nanoscale flow reactions from https://doi.org/10.1126/science.aap9112 screening a series of electrophiles and nucleophiles against 12 ligands (one blank), 8 bases (one blank), and four solvents."),
    ("ord_dataset-3b5db90e337942ea886b8f5bc5e3aa72",
    "Ni-catalyzed Suzuki Miyaura cross-coupling",
    "A nickel-catalyzed Suzuki-Miyaura cross-coupling reaction with various aryl chlorides and aryl boronic acids evaluated with phosphine ligands. From https://www.science.org/doi/10.1126/science.abj4213"),
    ("ord_dataset-cbcc4048add7468e850b6ec42549c70d",
    "Pd-catalyzed Buchwald-Hartwig C-N cross-coupling",
    "A palladium-catalyzed Buchwald-Hartwig cross coupling reaction with different precatalysts with different ligands, and bases."),
    ("ord_dataset-eeba974d3c284aed86d1c1d442260a1e",
    "HTE Suzuki coupling dataset",
    "Pd-catalyzed Suzuki coupling HTE dataset from Figure 2 of doi:10.1021/jacs.2c08592"),
]


for (_id, name, desc) in dsets:
    prefix = _id[12:14]
    fname = f"data/{prefix}/{_id}.pb.gz"
    #os.system(f"git lfs pull --include \"{fname}\"")
    dataset = message_helpers.load_message(fname, dataset_pb2.Dataset)
    dataset_web = message_helpers.fetch_dataset(_id)
    assert(json_format.MessageToJson(dataset).encode() ==
        json_format.MessageToJson(dataset_web).encode())
    print(f"Old name:  {dataset_web.name}")
    print(f"Old desc:  {dataset_web.description}")
    dataset.name = name
    dataset.description = desc
    print(f"New name:  {dataset.name}")
    print(f"New desc:  {dataset.description}")
    message_helpers.write_message(dataset, fname)
```

```
Old name:  
Old desc:  
New name:  Rapid material-sparing screening of 5760 Suzuki-Miyaura coupling reactions
New desc:  5760 nanoscale flow reactions from https://doi.org/10.1126/science.aap9112 screening a series of electrophiles and nucleophiles against 12 ligands (one blank), 8 bases (one blank), and four solvents.
Old name:  
Old desc:  
New name:  Ni-catalyzed Suzuki Miyaura cross-coupling
New desc:  A nickel-catalyzed Suzuki-Miyaura cross-coupling reaction with various aryl chlorides and aryl boronic acids evaluated with phosphine ligands. From https://www.science.org/doi/10.1126/science.abj4213
Old name:  
Old desc:  
New name:  Pd-catalyzed Buchwald-Hartwig C-N cross-coupling
New desc:  A palladium-catalyzed Buchwald-Hartwig cross coupling reaction with different precatalysts with different ligands, and bases.
Old name:  
Old desc:  
New name:  HTE Suzuki coupling dataset
New desc:  Pd-catalyzed Suzuki coupling HTE dataset from Figure 2 of doi:10.1021/jacs.2c08592
```