### PR TITLE
Correction to dataset description

### DIFF
--- a/data/5c/ord_dataset-5c9a10329a8a48968d18879a48bb8ab2.pb.gz
+++ b/data/5c/ord_dataset-5c9a10329a8a48968d18879a48bb8ab2.pb.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c63969a32d925ff665251db1dab1cfeb0b1d7825ad714d9327c155a6eb402857
-size 829174
+oid sha256:562bf7be62e80c0d073318c417a1e07007056b0358bd13f42cdbce4c0e098f8f
+size 829168


### PR DESCRIPTION
Remove 'GSK', and correct 'Janssen' spelling in dataset_description. Note that  no record_modified provenance added.