### PR TITLE
Upload Suzuki-coupling reaction dataset

### DIFF
--- a/attempts_dataset.pbtxt
+++ b/attempts_dataset.pbtxt
@@ -1,0 +1,7908 @@
+name: "attempts_dataset"
+description: "Enumerated by the ORD web interface."
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1(C)OB(c2cccs2)OC1(C)C"
+        }
+        amount {
+          moles {
+            value: 0.48
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=C(O)c1cc([N+](=O)[O-])cc([N+](=O)[O-])c1Br"
+        }
+        amount {
+          moles {
+            value: 0.397
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "O=C(O)c1cc([N+](=O)[O-])cc([N+](=O)[O-])c1c1cccs1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 5.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \'Celite\', \'column_type\': \'Silica gel\', \'flow_rate\': 40.0, \'solvent_1\': \'Hexane\', \'solvent_2\': \'Ethyl acetate\', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': \'Present\', \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(-)\', \'hit\': True, \'spectrum\': [ObjectId(\'64c0232192dfc781a063f141\'), ObjectId(\'64c0232192dfc781a063f143\')], \'notes\': \'\', \'mass\': 292.9865, \'calculated_mass\': 292.9868, \'formula\': \'C11H5N2O6S\', \'ionized_product\': \'[M-H]-\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c0232292dfc781a063f145\'), ObjectId(\'64c0232292dfc781a063f149\')], \'notes\': \'1H-NMR (500 MHz, acetone-d6) \316\264 8.81 (d, J = 2.32 Hz, 1H), 8.72 (d, J = 2.42 Hz, 1H), 7.70 (dd, J = 5.12, 1.14 Hz, 1H), 7.15 (m, 1H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c0232292dfc781a063f14b\'), ObjectId(\'64c0232392dfc781a063f14e\')], \'notes\': \'13C-NMR (125 MHz, acetone-d6) \316\264 165.8, 151.7, 147.4, 139.6, 132.2, 132.0, 129.5, 129.0, 127.3, 125.7, 120.0.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': [\'Hexane\', \'Ethyl acetate\']}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 0"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(B3OC(C)(C)C(C)(C)O3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=Cc1c(Br)cccc1N1CCCC1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(c3cccc(N4CCCC4)c3C=O)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 62.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 620.3217, \'calculated_mass\': 620.3232, \'formula\': \'C37H50NO3S2\', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c0240d92dfc781a063f151\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 10.13 (s, 1H), 7.53 \342\200\223 7.45 (m, 2H), 7.44 \342\200\223 7.36 (m, 2H), 6.96 \342\200\223 6.90 (m, 2H), 4.20 (dt, J = 5.6, 1.6 Hz, 4H), 3.34 (q, J = 6.1, 4.8 Hz, 4H), 2.07 \342\200\223 1.98 (m, 4H), 1.87 \342\200\223 1.75 (m, J = 6.3 Hz, 2H), 1.75 \342\200\223 1.43 (m, 7H), 1.45 \342\200\223 1.30 (m, 9H), 1.01 (q, J = 7.5 Hz, 6H), 0.92 (dt, J = 9.4, 7.0 Hz, 6H)\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c0240e92dfc781a063f153\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 189.3, 149.7, 144.8, 144.1, 140.7, 140.5, 132.9, 131.7, 131.6, 130.2, 130.1, 126.1, 121.6, 120.4, 119.0, 114.7, 76.2, 76.0, 52.5, 40.6, 30.4, 29.2, 25.9, 23.8, 23.8, 23.1, 14.1, 14.1, 11.3, 11.3\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 1"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4ccc(-c5cccs5)s4)s3)s1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCCCCCCCCCc1ccsc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCCCCCCCCCc1ccsc1c1ccc(-c2ccc(-c3ccc(-c4cccs4)s3)s2)s1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 5.6
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [], \'notes\': \'EI+\', \'mass\': 580.1419, \'calculated_mass\': 580.1421, \'formula\': \'C32H36S5\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c025dc92dfc781a063f156\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.23 (dd, J = 5.1, 1.2 Hz, 1H), 7.19 \342\200\223 7.17 (m, 2H), 7.12 (dd, J = 3.8, 1.5 Hz, 1H), 7.11 \342\200\223 7.07 (m, 4H), 7.03 (td, J = 4.5, 2.5 Hz, 2H), 6.94 (d, J = 5.2 Hz, 1H), 2.80 \342\200\223 2.75 (m, 2H), 1.66 (q, J = 7.5 Hz, 2H), 1.40 \342\200\223 1.22 (m, 18H), 0.87 (t, J = 6.9 Hz, 3H).;\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c025dc92dfc781a063f158\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 140.10, 137.20, 136.77, 136.50, 136.21, 136.04, 136.00, 135.64, 130.39, 130.27, 128.07, 126.71, 124.74, 124.55, 124.48, 124.45, 124.41, 124.39, 124.10, 124.07, 123.91, 32.09, 30.81, 29.85, 29.82, 29.76, 29.66, 29.61, 29.53, 29.41, 22.85, 14.28.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 2"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3cccc([B-]45OC(=O)C[N+]4(C)CC(=O)O5)c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Brc1cc(OCc2ccccc2)cc(OCc2ccccc2)c1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3cccc(c4cc(OCc5ccccc5)cc(OCc5ccccc5)c4)c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 42.7
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "purification_steps"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 3"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3cccs3)cc1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CN1CCN(S(=O)(=O)c2ccc(Br)cc2)CC1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CN1CCN(S(=O)(=O)c2ccc(c3ccc(-c4cccs4)cc3)cc2)CC1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 4.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [], \'notes\': \'\', \'mass\': 399.1194, \'calculated_mass\': 399.1201, \'formula\': \'C21H23N2O2S2 \', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c027de92dfc781a063f160\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.85 \342\200\223 7.78 (m, 2H), 7.77 \342\200\223 7.69 (m, 4H), 7.64 \342\200\223 7.58 (m, 2H), 7.38 (dd, J = 3.6, 1.2 Hz, 1H), 7.32 (dd, J = 5.1, 1.2 Hz, 1H), 7.11 (dd, J = 5.1, 3.6 Hz, 1H), 3.21 (s, 4H), 2.75 \342\200\223 2.63 (m, 4H), 2.39 (s, 3H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c027df92dfc781a063f162\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 145.51, 143.60, 138.13, 134.83, 133.96, 128.45, 128.34, 127.94, 127.65, 126.61, 125.53, 123.72, 53.93, 45.36.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 4"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc(-c4ccc([B-]56OC(=O)C[N+]5(C)CC(=O)O6)s4)s3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.135
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "COc1cc2c(Nc3ccc(Br)cc3F)ncnc2cc1OCC1CCN(C)CC1"
+        }
+        amount {
+          moles {
+            value: 0.112
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc(-c4ccc(c5ccc(Nc6ncnc7cc(OCC8CCN(C)CC8)c(OC)cc67)c(F)c5)s4)s3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 5.5
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'Prep HPLC\', \'loading_method\': \'Solution\', \'column_type\': \'C-18\', \'flow_rate\': 40.0, \'solvent_1\': \'Acetonitrile\', \'solvent_2\': \'Water\', \'uv_vis_spectrum\': [], \'HPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"time\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_time\': 0, \'hit_product\': \'Present\', \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [], \'notes\': \'Missing the actual file.\', \'mass\': 1004.3883, \'calculated_mass\': 1004.3873, \'formula\': \'C56H65FN4O4S4\', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c0280b92dfc781a063f165\'), ObjectId(\'64c0280b92dfc781a063f169\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 8.72 (s, 1H), 8.56 (s, 1H), 7.71 (s, 1H), 7.61 \342\200\223 7.31 (m, 6H), 7.24 \342\200\223 7.02 (m, 4H), 4.31 (t, J = 6.8 Hz, 2H), 4.21 \342\200\223 4.17 (m, 2H), 4.12 \342\200\223 4.02 (m, 4H), 3.64 \342\200\223 3.46 (m, 2H), 2.75 (s, 3H), 2.23 \342\200\223 2.13 (m, 2H), 2.06 \342\200\223 1.97 (m, 2H), 1.85 \342\200\223 1.81 (m, 1H), 1.76 \342\200\223 1.67 (m, 4H), 1.64 \342\200\223 1.59 (m, 2H), 1.56 \342\200\223 1.50 (m, 2H), 1.44 \342\200\223 1.41 (m, 4H), 1.25 (s, 6H), 1.10 \342\200\223 1.00 (m, 6H), 0.99 \342\200\223 0.94 (m, 6H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c0280c92dfc781a063f16b\')], \'notes\': \'13C-NMR (125 MHz, CDCl3) \316\264 132.33, 130.92, 128.85, 116.04, 65.58, 40.70, 30.59, 30.45, 29.72, 29.22, 23.90, 23.15, 19.20, 14.19, 13.75, 11.36. \\n\\nLow solubility precludes observation of most carbon signals.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [ObjectId(\'64c0280c92dfc781a063f16e\'), ObjectId(\'64c0280d92dfc781a063f172\')], \'notes\': \'19F NMR (471 MHz, CDCl3) \316\264 -129.8.\'}, \'observations\': \'\'}], \'solvents\': [\'Acetonitrile\', \'Water\']}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 5"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3cccs3)s1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Brc1c2ccccc2c(-c2ccccc2)c2ccccc12"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "c1ccc(-c2c3ccccc3c(c3ccc(-c4cccs4)s3)c3ccccc23)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 34.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [], \'notes\': \'EI+\', \'mass\': 418.0867, \'calculated_mass\': 418.085, \'formula\': \'C28H18S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c0298192dfc781a063f175\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 8.05 (d, J = 8.8 Hz, 2H), 7.70 (d, J = 8.8 Hz, 2H), 7.62 (dd, J = 7.6, 6.2 Hz, 2H), 7.59 \342\200\223 7.53 (m, 1H), 7.50 \342\200\223 7.42 (m, 4H), 7.42 \342\200\223 7.33 (m, 3H), 7.31 \342\200\223 7.21 (m, 2H), 7.14 (dd, J = 3.6, 1.1 Hz, 1H), 7.08 (t, J = 4.4 Hz, 1H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c0298192dfc781a063f177\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 138.8, 138.2, 137.3, 131.5, 131.1, 130.3, 129.8, 128.4, 128.1, 127.9, 127.6, 127.0, 126.6, 125.7, 125.2, 124.4, 123.8.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 6"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc4oc([B-]56OC(=O)C(C)(C)[N+]5(C)C(C)(C)C(=O)O6)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Brc1cccc([Si](c2ccccc2)(c2ccccc2)c2ccccc2)c1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc4oc(c5cccc([Si](c6ccccc6)(c6ccccc6)c6ccccc6)c5)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 17.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [], \'notes\': \'\', \'mass\': 897.3796, \'calculated_mass\': 897.3831, \'formula\': \'C58H61O3SiS2 \', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c02a9692dfc781a063f17a\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 8.11 (t, J = 1.4 Hz, 1H), 7.97 (dt, J = 7.7, 1.6 Hz, 1H), 7.91 (d, J = 1.9 Hz, 1H), 7.75 \342\200\223 7.31 (m, 22H), 6.97 (s, 1H), 4.23 (s, 4H), 1.86 (dt, J = 11.9, 6.0 Hz, 2H), 1.77 \342\200\223 1.53 (m, 10H), 1.44 (ddq, J = 9.9, 7.4, 3.7, 3.1 Hz, 8H), 1.06 (td, J = 7.4, 3.5 Hz, 6H), 0.97 (t, J = 6.9 Hz, 6H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c02a9692dfc781a063f17c\')], \'notes\': \'3C NMR (126 MHz, CDCl3) \316\264 157.18, 155.13, 146.11, 144.14, 137.03, 136.57, 135.35, 133.96, 132.89, 131.59, 130.03, 129.94, 129.79, 128.54, 128.28, 128.16, 126.37, 125.83, 123.40, 120.55, 119.01, 115.32, 111.77, 106.94, 101.62, 76.21, 76.18, 40.85, 40.83, 34.82, 31.74, 30.64, 30.61, 29.41, 29.37, 27.06, 25.43, 24.04, 24.03, 23.33, 23.29, 20.85, 14.35, 14.33, 11.50.;\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 7"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc4oc([B-]56OC(=O)C(C)(C)[N+]5(C)C(C)(C)C(=O)O6)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Ic1ccc(N(c2ccccc2)c2ccccc2)cc1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc4oc(c5ccc(N(c6ccccc6)c6ccccc6)cc5)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 17.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 806.3677, \'calculated_mass\': 806.3702, \'formula\': \'C52H56NO3S2\', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c02cd992dfc781a063f17f\')], \'notes\': \'1H NMR (500 MHz, acetone-d6) \316\264 8.01 (d, J = 1.9 Hz, 1H), 7.82 (dd, J = 7.0, 1.8 Hz, 3H), 7.75 (dd, J = 8.5, 1.9 Hz, 1H), 7.66 \342\200\223 7.60 (m, 2H), 7.54 (d, J = 5.6 Hz, 1H), 7.39 \342\200\223 7.32 (m, 4H), 7.21 (d, J = 0.8 Hz, 1H), 7.17 \342\200\223 7.06 (m, 8H), 4.27 (dd, J = 11.1, 5.3 Hz, 4H), 1.85 (tt, J = 10.2, 5.0 Hz, 2H), 1.78 \342\200\223 1.40 (m, 19H), 1.06 (t, J = 7.4 Hz, 6H), 0.95 (td, J = 7.1, 3.2 Hz, 6H).; \'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c02cda92dfc781a063f181\')], \'notes\': \'13C NMR (126 MHz, acetone-d6) \316\264 158.13, 155.75, 149.59, 148.15, 145.45, 145.19, 144.92, 133.22, 132.32, 131.39, 131.37, 130.46, 130.39, 130.22, 129.92, 127.54, 126.91, 125.91, 124.69, 124.27, 123.72, 123.22, 121.12, 119.48, 116.11, 112.32, 101.07, 76.72, 76.62, 41.60, 31.25, 24.64, 24.62, 23.86, 23.84, 23.81, 14.47, 14.45, 11.73, 11.71\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 8"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc4oc([B-]56OC(=O)C(C)(C)[N+]5(C)C(C)(C)C(=O)O6)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Cc1cc(N2CCN(C)CC2)ncc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc4oc(c5cnc(N6CCN(C)CC6)cc5C)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 28.7
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [ObjectId(\'64c02d8092dfc781a063f184\'), ObjectId(\'64c02d8092dfc781a063f186\')], \'notes\': \'HRMS (ESI+) calculated for C45H58N3O3S2 [M+H]+ m/z\\n752.3920, found 752.3914.\', \'mass\': 752.3914, \'calculated_mass\': 752.392, \'formula\': \'C45H58N3O3S2\', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c02d8192dfc781a063f188\'), ObjectId(\'64c02d8192dfc781a063f18c\')], \'notes\': \'1HNMR (500 MHz, CDCl3) \316\264 8.61 (s, 1H), 7.93 (d, J = 1.7 Hz, 1H), 7.69 \342\200\223 7.63 (m, 2H), 7.55 (d, J = 8.5 Hz, 1H), 7.47 (d, J = 5.5 Hz, 1H), 7.35 (d, J = 5.5 Hz, 1H), 6.81 (s, 1H), 6.55 (s, 1H), 4.22 (dd, J = 5.6, 2.6 Hz, 4H), 3.70 \342\200\223 3.65 (m, 4H), 2.56 (t, J = 5.1 Hz, 4H), 2.53 (s, 3H), 2.38 (s, 3H), 1.84 (dt, J = 12.0, 6.0 Hz, 2H), 1.72 (ddq, J = 10.7, 6.9, 3.5 Hz, 2H), 1.69 \342\200\223 1.57 (m, 4H), 1.56 \342\200\223 1.49 (m, 2H), 1.48 \342\200\223 1.37 (m, 8H), 1.05 (td, J = 7.5, 3.8 Hz, 6H), 0.96 (td, J = 7.0, 1.7 Hz, 6H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c02d8192dfc781a063f18e\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 159.0, 155.7, 154.5, 147.8, 146.1, 144.5, 144.4, 144.1, 132.6, 131.4, 130.2, 129.9, 129.5, 129.1, 125.6, 122.8, 120.4, 118.5, 116.4, 115.1, 111.3, 108.0, 103.3, 76.0, 76.0, 54.8, 46.1, 44.9, 40.7, 40.7, 30.5, 30.4, 29.2, 29.2, 23.9, 23.9, 23.2, 23.1, 21.9, 14.2, 14.2, 11.3.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 9"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(B3OC(C)(C)C(C)(C)O3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.5
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=S(=O)(c1cccc(Br)c1)N1CCC1"
+        }
+        amount {
+          moles {
+            value: 0.6
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "K3PO4"
+        }
+        identifiers {
+          type: SMILES
+          value: "[K+].[K+].[K+].[O-]P([O-])([O-])=O"
+        }
+        amount {
+          moles {
+            value: 3.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G2"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1310584-14-5"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 4.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "Used 4 mL of THF as solvent"
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(c3cccc(S(=O)(=O)N4CCC4)c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 19.3
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \'Celite\', \'column_type\': \'Silica gel\', \'flow_rate\': 40.0, \'solvent_1\': \'Hexane\', \'solvent_2\': \'Ethyl acetate\', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":0,\"1\":0},\"end\":{\"0\":0,\"1\":10},\"volume\":{\"0\":2,\"1\":10}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': \'Present\', \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [ObjectId(\'64c02d8992dfc781a063f191\'), ObjectId(\'64c02d8992dfc781a063f193\')], \'notes\': \'\', \'mass\': 642.2722, \'calculated_mass\': 642.2745, \'formula\': \'C35H48NO4S3 \', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c02d8a92dfc781a063f195\'), ObjectId(\'64c02d8a92dfc781a063f199\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 8.18 (t, J = 1.8 Hz, 1H), 7.99 (dt, J = 7.8, 1.4 Hz, 1H), 7.84 \342\200\223 7.77 (m, 2H), 7.66 (t, J = 7.8 Hz, 1H), 7.48 (d, J = 5.5 Hz, 1H), 7.40 (d, J = 5.5 Hz, 1H), 4.22 (dd, J = 7.6, 5.6 Hz, 4H), 3.86 (t, J = 7.6 Hz, 4H), 2.12 (p, J = 7.6 Hz, 2H), 1.85 (dhept, J = 12.0, 6.1 Hz, 2H), 1.72 (dtt, J = 14.1, 6.9, 3.8 Hz, 2H), 1.62 (ttd, J = 14.2, 7.0, 2.4 Hz, 4H), 1.55 \342\200\223 1.48 (m, 2H), 1.46 \342\200\223 1.36 (m, 8H), 1.03 (td, J = 7.5, 2.4 Hz, 6H), 0.94 (td, J = 7.0, 4.1 Hz, 6H)\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c02d8b92dfc781a063f19c\'), ObjectId(\'64c02d8b92dfc781a063f19f\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 145.22, 144.58, 141.15, 135.90, 135.88, 132.36, 132.20, 130.93, 130.54, 129.92, 129.30, 127.73, 126.62, 125.92, 120.54, 117.57, 77.36, 76.49, 76.35, 51.24, 40.83, 40.77, 30.57, 29.35, 29.33, 23.99, 23.94, 23.29, 23.28, 15.49, 14.31, 11.47, 11.42.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': [\'Hexane\', \'Ethyl acetate\']}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 10"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1cccc(-c3cccs3)c1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCCCCCCCCCc1ccsc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCCCCCCCCCc1ccsc1c1cccc(-c2cccs2)c1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 39
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': \'Present\', \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [], \'notes\': \'EI+\', \'mass\': 410.21155, \'calculated_mass\': 410.2102, \'formula\': \'C26H34S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c02e4192dfc781a063f1a2\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.71 (d, J = 1.9 Hz, 1H), 7.60 (dt, J = 7.7, 1.4 Hz, 1H), 7.44 (t, J = 7.7 Hz, 1H), 7.37 (q, J = 2.6 Hz, 2H), 7.32 (d, J = 5.1 Hz, 1H), 7.27 (s, 1H), 7.12 (dd, J = 5.1, 3.6 Hz, 1H), 7.02 (d, J = 5.2 Hz, 1H), 2.75 \342\200\223 2.67 (m, 2H), 1.65 (q, J = 7.8 Hz, 2H), 1.40 \342\200\223 1.22 (m, 18H), 0.91 (t, J = 6.9 Hz, 3H).;\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c02e4192dfc781a063f1a4\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 144.1, 139.1, 137.3, 135.5, 134.6, 129.6, 129.0, 128.5, 128.1, 126.9, 125.1, 124.8, 123.8, 123.3, 32.0, 31.1, 29.7, 29.7, 29.6, 29.5, 29.5, 29.4, 28.7, 22.7, 14.2.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 11"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1(C)OB(c2cccs2)OC1(C)C"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCCCCCCCCCc1ccsc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCCCCCCCCCc1ccsc1c1cccs1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 32.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [], \'notes\': \'EI+\', \'mass\': 3334.18, \'calculated_mass\': 334.1789, \'formula\': \'C20H30S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c02f0092dfc781a063f1a7\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.18 (dd, J = 5.2, 1.3 Hz, 1H), 7.06 (d, J = 5.2 Hz, 1H), 7.01 (dd, J = 3.7, 1.1 Hz, 1H), 6.95 (dd, J = 5.2, 3.6 Hz, 1H), 6.83 (d, J = 5.2 Hz, 1H), 2.68 \342\200\223 2.62 (m, 2H), 1.53 (p, J = 7.5 Hz, 2H), 1.31 \342\200\223 1.15 (m, 18H), 0.80 (t, J = 6.9 Hz, 3H).; \'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c02f0092dfc781a063f1a9\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 139.6, 136.2, 130.5, 129.8, 127.3, 125.9, 125.2, 123.6, 31.9, 31.6, 30.7, 29.7, 29.6, 29.6, 29.5, 29.5, 29.4, 29.4, 29.1, 22.7, 14.1.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 12"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3cccs3)cc1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCCCCCCCCCc1ccsc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCCCCCCCCCc1ccsc1c1ccc(-c2cccs2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 27.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [], \'notes\': \'EI+\', \'mass\': 410.21155, \'calculated_mass\': 410.2102, \'formula\': \'C26H34S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c02fa192dfc781a063f1ac\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.70 \342\200\223 7.64 (m, 2H), 7.51 \342\200\223 7.44 (m, 2H), 7.37 (dd, J = 3.6, 1.2 Hz, 1H), 7.31 (dd, J = 5.1, 1.1 Hz, 1H), 7.25 (d, J = 5.2 Hz, 1H), 7.11 (dd, J = 5.1, 3.6 Hz, 1H), 7.00 (d, J = 5.1 Hz, 1H), 2.74 \342\200\223 2.66 (m, 2H), 1.64 (p, J = 7.4 Hz, 2H), 1.38 \342\200\223 1.23 (m, 18H), 0.90 (t, J = 6.9 Hz, 3H). \'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c02fa192dfc781a063f1ae\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 144.10, 139.03, 137.40, 134.12, 133.42, 129.88, 129.80, 129.01, 128.24, 126.09, 126.04, 125.07, 123.87, 123.30, 32.07, 31.16, 29.83, 29.80, 29.73, 29.64, 29.57, 29.50, 28.88, 22.84, 14.28.;\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 13"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3cc4sc([B-]56OC(=O)C[N+]5(C)CC(=O)O6)cc4s3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.0672
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC(C)(C)OC(=O)NCCNS(=O)(=O)c1ccc(Br)cc1"
+        }
+        amount {
+          moles {
+            value: 0.056
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3cc4sc(c5ccc(S(=O)(=O)NCCNC(=O)OC(C)(C)C)cc5)cc4s3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 9.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \'Celite\', \'column_type\': \'Silica gel\', \'flow_rate\': 40.0, \'solvent_1\': \'Hexane\', \'solvent_2\': \'Ethyl acetate\', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': \'Present\', \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [ObjectId(\'64c0305892dfc781a063f1b1\'), ObjectId(\'64c0305892dfc781a063f1b3\')], \'notes\': \'\', \'mass\': 882.2883, \'calculated_mass\': 882.2893, \'formula\': \'C45H58N2O6S5 \', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c0305992dfc781a063f1b5\'), ObjectId(\'64c0305992dfc781a063f1b9\')], \'notes\': \'1H NMR (500 MHz, acetone-d6) \316\264 7.94 (s, 1H), 7.90 (s, 4H), 7.75 (d, J = 6.4 Hz, 1H), 7.69 \342\200\223 7.65 (m, 2H), 7.53 (d, J = 5.5 Hz, 1H), 6.67 (d, J = 5.5 Hz, 1H), 6.08 (t, J = 5.8 Hz, 1H), 4.30 \342\200\223 4.21 (m, 4H), 3.20 (q, J = 6.1 Hz, 2H), 3.06 (q, J = 6.1 Hz, 2H), 1.89 \342\200\223 1.41 (m, 18H), 1.39 (d, J = 2.2 Hz, 9H), 1.11 \342\200\223 1.02 (m, 6H), 0.96 (m, 6H)\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c0305992dfc781a063f1bb\'), ObjectId(\'64c0305a92dfc781a063f1be\')], \'notes\': \'13C NMR (126 MHz, acetone-d6) \316\264 156.94, 145.57, 145.54, 145.05, 141.12, 140.85, 140.78, 140.30, 138.91, 137.34, 134.17, 132.94, 132.46, 131.67, 129.84, 129.46, 128.73, 128.09, 127.60, 126.67, 125.97, 125.80, 124.25, 121.13, 118.96, 118.65, 117.21, 116.77, 78.97, 76.68, 76.66, 62.76, 41.59, 41.57, 41.05, 31.29, 31.23, 28.59, 24.63, 24.61, 23.84, 23.82, 23.80, 14.49, 14.46, 11.72.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': [\'Hexane\', \'Ethyl acetate\']}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 14"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1(C)C(=O)O[B-]2(c3cc4sc(-c5ccc(-c6cccs6)s5)cc4s3)OC(=O)C(C)(C)[N+]21C"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCCCCCCCCCc1ccsc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCCCCCCCCCc1ccsc1c1cc2sc(-c3ccc(-c4cccs4)s3)cc2s1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 7.6
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [], \'notes\': \'EI+\', \'mass\': 554.1254, \'calculated_mass\': 554.1264, \'formula\': \'C30H34S5\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c0305b92dfc781a063f1c2\')], \'notes\': \'1H NMR (499 MHz, CDCl3) \316\264 1H NMR (500 MHz, CDCl3) \316\264 7.31 (s, 1H), 7.26 \342\200\223 7.17 (m, 4H), 7.14 \342\200\223 7.08 (m, 2H), 7.04 (dd, J = 5.1, 3.6 Hz, 1H), 6.96 (d, J = 5.2 Hz, 1H), 2.79 (t, J = 7.8 Hz, 2H), 1.65 (p, J = 7.6 Hz, 2H), 1.41 \342\200\223 1.22 (m, 18H), 0.87 (t, J = 6.8 Hz, 3H). \'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c0305b92dfc781a063f1c4\')], \'notes\': \' 13C NMR (126 MHz, CDCl3) \316\264 140.3, 139.5, 138.3, 138.1, 138.1, 137.0, 136.6, 136.4, 130.6, 130.1, 127.9, 124.7, 124.5, 124.4, 124.4, 123.8, 118.0, 115.6, 31.9, 30.8, 29.7, 29.7, 29.6, 29.5, 29.4, 29.4, 29.2, 22.7, 14.1. \'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 15"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4cccs4)s3)[se]1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCCCCCCCCCc1ccsc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCCCCCCCCCc1ccsc1c1ccc(-c2ccc(-c3cccs3)s2)[se]1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 1.5
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [], \'notes\': \'EI+\', \'mass\': 546.0969, \'calculated_mass\': 546.0988, \'formula\': \'C28H34S3Se\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c0310f92dfc781a063f1c7\')], \'notes\': \'1H NMR (500 MHz, acetone-d6) \316\264 7.46 (dd, J = 5.2, 1.1 Hz, 1H), 7.42 (d, J = 4.0 Hz, 1H), 7.38 (d, J = 5.2 Hz, 1H), 7.32 (dd, J = 3.6, 1.1 Hz, 1H), 7.27 (d, J = 4.0 Hz, 1H), 7.24 \342\200\223 7.22 (m, 2H), 7.10 (dd, J = 5.1, 3.6 Hz, 1H), 7.04 (d, J = 5.2 Hz, 1H), 1.67 (p, J = 7.6 Hz, 2H), 1.45 \342\200\223 1.18 (m, 20H), 0.91 \342\200\223 0.83 (m, 3H).;\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c0311092dfc781a063f1c9\')], \'notes\': \'13C NMR (126 MHz, acetone-d6) \316\264 142.49, 140.86, 140.58, 138.66, 137.48, 137.27, 133.21, 131.39, 129.68, 129.09, 127.15, 126.17, 126.04, 125.56, 125.29, 124.93, 32.66, 31.32, 29.21, 23.34, 14.36.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 16"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]14CC(=O)O[B-]1(c3cccc(c2cccs2)c3)OC(=O)C4"
+        }
+        amount {
+          moles {
+            value: 0.32
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCCCCCc1ccsc1Br"
+        }
+        amount {
+          moles {
+            value: 0.264
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCCCCCc1ccsc1c3cccc(c2cccs2)c3"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 80.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw Product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'mass\': 0.0, \'calculated_mass\': 0.0, \'spectrum\': [ObjectId(\'666274579711bb6937a626a1\'), ObjectId(\'666274579711bb6937a626a3\')], \'formula\': \'\', \'ionized_product\': \' \', \'notes\': \'\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'666274579711bb6937a626a5\'), ObjectId(\'666274579711bb6937a626a7\')], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'666274579711bb6937a626ab\'), ObjectId(\'666274579711bb6937a626ae\')], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \'Celite\', \'solvents\': [\'Hexane\'], \'column_type\': \'Silica gel\', \'flow_rate\': 40.0, \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":0,\"1\":0},\"end\":{\"0\":0,\"1\":10},\"volume\":{\"0\":2,\"1\":10}}\', \'characterization\': [{\'elution_volume\': 0, \'hit_product\': \'Present\', \'hit_boron\': False, \'hit_halide\': False, \'hit_degrade\': False, \'observations\': \'\', \'MS\': {\'ionization_method\': \'EI\', \'mass\': 354.147, \'hit\': True, \'calculated_mass\': 354.1476, \'formula\': \'C22H26S2 \', \'spectrum\': [ObjectId(\'64c031cd92dfc781a063f1cc\')], \'ionized_product\': \'[M]+\', \'notes\': \'\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c031cd92dfc781a063f1ce\'), ObjectId(\'64c031ce92dfc781a063f1d2\')], \'notes\': \'1H NMR (500 MHz, acetone-d6) \316\264 7.72 (t, J = 1.9 Hz, 1H), 7.69 \342\200\223 7.63 (m, 1H), 7.52 \342\200\223 7.42 (m, 3H), 7.40 \342\200\223 7.35 (m, 2H), 7.12 (dd, J = 5.1, 3.6 Hz, 1H), 7.05 (d, J = 5.2 Hz, 1H), 2.74 \342\200\223 2.67 (m, 2H), 1.69 \342\200\223 1.59 (m, 2H), 1.35 \342\200\223 1.16 (m, 10H), 0.84 (t, J = 7.0 Hz, 3H)\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c031ce92dfc781a063f1d4\'), ObjectId(\'64c031cf92dfc781a063f1d7\')], \'notes\': \'13C NMR (126 MHz, acetone-d6) \316\264 144.35, 139.78, 137.74, 136.44, 135.57, 130.60, 130.23, 129.14, 129.09, 127.02, 126.19, 125.43, 124.95, 124.54, 32.56, 31.74, 30.13, 30.05, 29.98, 29.26, 23.29, 14.40.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'solvents\': [], \'column_type\': \'\', \'flow_rate\': 0.0, \'uv_vis_spectrum\': [], \'MPLC_method\': \'\', \'characterization\': [{\'elution_volume\': 0, \'hit_product\': \'Present\', \'hit_boron\': False, \'hit_halide\': False, \'hit_degrade\': False, \'MS\': {\'ionization_method\': \' \', \'mass\': 0.0, \'hit\': False, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \', \'notes\': \'\', \'spectrum\': []}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 17"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc([B-]45OC(=O)C[N+]4(C)CC(=O)O5)s3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "COC(=O)c1cc(Br)cc(N)c1N"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc(c4cc(N)c(N)c(C(=O)OC)c4)s3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 9.6
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'MALDI\', \'hit\': True, \'spectrum\': [], \'notes\': \'\', \'mass\': 692.2771, \'calculated_mass\': 692.2776, \'formula\': \'C38H48N2O4S3\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c031f192dfc781a063f1da\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.78 (d, J = 2.1 Hz, 1H), 7.49 (s, 1H), 7.45 (d, J = 5.5 Hz, 1H), 7.35 (d, J = 5.5 Hz, 1H), 7.25 (d, J = 3.8 Hz, 1H), 7.14 \342\200\223 7.12 (m, 2H), 4.20 \342\200\223 4.17 (m, 4H), 3.93 (s, 3H), 3.45 (s, 2H), 1.85 \342\200\223 1.80 (m, 2H), 1.73 \342\200\223 1.54 (m, 10H), 1.43 \342\200\223 1.40 (m, 6H), 1.04 (q, J = 7.4 Hz, 6H), 0.99 \342\200\223 0.94 (m, 6H).;\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c031f192dfc781a063f1dc\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 168.77, 144.81, 144.58, 144.38, 141.43, 136.87, 135.33, 132.31, 131.84, 130.59, 128.74, 126.29, 125.98, 122.94, 122.50, 120.54, 120.30, 118.09, 116.85, 115.49, 112.07, 76.20, 76.19, 51.94, 40.84, 40.81, 30.63, 30.58, 29.40, 29.35, 24.03, 24.00, 23.35, 23.28, 14.37, 14.32, 11.50, 11.48.;\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 18"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4cccs4)s3)cc1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Brc1ccc2c(c1)C1(c3ccccc3Oc3ccccc31)c1ccccc1-2"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 25.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "c1csc(-c2ccc(-c3ccc(c4ccc5c(c4)C4(c6ccccc6Oc6ccccc64)c4ccccc4-5)cc3)s2)c1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 2.3
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [], \'notes\': \'\', \'mass\': 572.1268, \'calculated_mass\': 572.1269, \'formula\': \'C39H24OS2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c0336f92dfc781a063f1e1\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.87 (d, J = 7.9 Hz, 1H), 7.83 (dt, J = 7.6, 0.9 Hz, 1H), 7.66 (dd, J = 8.0, 1.7 Hz, 1H), 7.61 \342\200\223 7.56 (m, 2H), 7.54 \342\200\223 7.49 (m, 2H), 7.44 \342\200\223 7.36 (m, 2H), 7.26 (d, J = 1.9 Hz, 1H), 7.25 \342\200\223 7.17 (m, 8H), 7.14 (d, J = 3.8 Hz, 1H), 7.03 (dd, J = 5.1, 3.6 Hz, 1H), 6.80 (ddd, J = 8.3, 7.0, 1.5 Hz, 2H), 6.48 (dd, J = 7.9, 1.5 Hz, 2H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c0336f92dfc781a063f1e3\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 155.8, 155.4, 151.4, 142.7, 140.6, 139.9, 139.2, 139.2, 137.4, 136.8, 133.0, 128.5, 128.2, 128.0, 127.9, 127.9, 127.5, 126.7, 125.8, 125.8, 124.8, 124.7, 124.4, 124.1, 123.8, 123.7, 123.4, 120.4, 120.0, 116.8, 54.4.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 19"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3cccc([B-]45OC(=O)C[N+]4(C)CC(=O)O5)c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Nc1c(S(=O)(=O)O)cc(Br)c2c1C(=O)c1ccccc1C2=O"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3cccc(c4cc(S(=O)(=O)O)c(N)c5c4C(=O)c4ccccc4C5=O)c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 4.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \'Celite\', \'column_type\': \'Silica gel\', \'flow_rate\': 40.0, \'solvent_1\': \'Hexane\', \'solvent_2\': \'Ethyl acetate\', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":0,\"1\":0},\"end\":{\"0\":0,\"1\":10},\"volume\":{\"0\":2,\"1\":10}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': \'Present\', \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(-)\', \'hit\': True, \'spectrum\': [ObjectId(\'64c034a492dfc781a063f1e6\')], \'notes\': \'\', \'mass\': 822.259, \'calculated_mass\': 822.2593, \'formula\': \'C46H48NO7S3 \', \'ionized_product\': \'[M-H]-\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64c034a592dfc781a063f1e8\'), ObjectId(\'64c034a592dfc781a063f1ec\')], \'notes\': \'1H NMR (500 MHz, MeOD) \316\264 8.32 \342\200\223 8.25 (m, 1H), 7.96 (d, J = 5.7 Hz, 2H), 7.85 \342\200\223 7.77 (m, 1H), 7.76 \342\200\223 7.67 (m, 3H), 7.66 \342\200\223 7.59 (m, 1H), 7.55 \342\200\223 7.42 (m, 3H), 7.32 \342\200\223 7.25 (m, 1H), 4.19 (d, J = 5.0 Hz, 4H), 1.81 \342\200\223 1.28 (m, 18H), 1.01 (dt, J = 13.0, 7.4 Hz, 6H), 0.87 (dt, J = 22.5, 7.1 Hz, 6H)\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64c034a692dfc781a063f1ef\'), ObjectId(\'64c034a692dfc781a063f1f2\')], \'notes\': \'13C NMR (126 MHz, MeOD) \316\264 186.59, 185.99, 149.87, 145.86, 145.55, 145.20, 145.05, 138.24, 135.74, 135.31, 135.27, 135.20, 135.06, 134.78, 134.51, 133.59, 132.96, 131.91, 131.71, 130.37, 130.15, 129.70, 127.56, 127.50, 127.34, 125.50, 121.12, 116.51, 115.80, 76.94, 42.13, 42.11, 31.70, 31.66, 30.42, 30.40, 25.06, 25.05, 24.19, 24.16, 14.49, 14.47, 11.80\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': [\'Hexane\', \'Ethyl acetate\']}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 20"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1(C)OB(c2ccc(-c3cccs3)s2)OC1(C)C"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=C1c2ccccc2C(=O)c2cc(Br)ccc21"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "O=C1c2ccccc2C(=O)c2cc(c3ccc(-c4cccs4)s3)ccc21"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 1.21
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [ObjectId(\'64d544b03be5587105612f31\'), ObjectId(\'64d544b13be5587105612f33\'), ObjectId(\'64d544b13be5587105612f35\')], \'notes\': \'HRMS (EI+) calculated for C22H12O2S2 [M]+ m/z 372.0279, found 372.0273\', \'mass\': 372.0273, \'calculated_mass\': 372.0279, \'formula\': \'C22H12O2S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d544b23be5587105612f37\'), ObjectId(\'64d544b23be5587105612f3b\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 8.51 (d, J = 2.0 Hz, 1H), 8.37 \342\200\223 8.30 (m, 3H), 7.98 (dd, J = 8.1, 2.0 Hz, 1H), 7.86 \342\200\223 7.79 (m, 2H), 7.52 (d, J = 3.9 Hz, 1H), 7.31 \342\200\223 7.27 (m, 2H), 7.24 (d, J = 3.8 Hz, 1H), 7.07 (dd, J = 5.1, 3.7 Hz, 1H).;\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d544b23be5587105612f3d\')], \'notes\': \' 13C NMR (126 MHz, CDCl3) \316\264 183.1, 182.4, 140.5, 139.7, 139.6, 136.8, 134.3, 134.1, 134.0, 133.7, 133.5, 131.8, 130.1, 128.3, 128.1, 127.3, 127.3, 126.4, 125.3, 125.0, 124.4, 123.4.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 21"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc(B4OC(C)(C)C(C)(C)O4)[se]3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Cc1ccc(I)s1"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc(c4ccc(C)s4)[se]3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 11.9
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [ObjectId(\'64d548d03be5587105612f40\')], \'notes\': \'HRMS (EI+) calculated for C35H44O2S3Se [M]+ m/z 672.1669, found 672.1672\', \'mass\': 672.1672, \'calculated_mass\': 672.1669, \'formula\': \'C35H44O2S3Se\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d548d03be5587105612f42\'), ObjectId(\'64d548d13be5587105612f45\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.45 (d, J = 5.7 Hz, 1H), 7.41 (s, 1H), 7.35 (dd, J = 7.0, 4.7 Hz, 2H), 7.18 (d, J = 4.0 Hz, 1H), 6.96 (d, J = 3.5 Hz, 1H), 6.68 (d, J = 3.5 Hz, 1H), 4.17 (t, J = 4.8 Hz, 4H), 2.49 (s, 3H), 1.81 (hept, J = 5.9 Hz, 2H), 1.76 \342\200\223 1.56 (m, 6H), 1.51 (td, J = 8.4, 5.9 Hz, 2H), 1.41 (dtd, J = 13.8, 9.9, 8.8, 4.9 Hz, 8H), 1.03 (q, J = 7.4 Hz, 6H), 0.96 (q, J = 6.5 Hz, 6H)\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d548d13be5587105612f47\'), ObjectId(\'64d548d13be5587105612f49\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 144.5, 144.2, 142.9, 140.1, 140.0, 138.4, 136.9, 132.1, 131.9, 130.4, 128.7, 128.2, 126.2, 125.9, 125.6, 124.6, 120.4, 116.5, 76.0, 40.7, 30.5, 30.4, 29.7, 29.2, 29.2, 23.8, 23.2, 23.1, 15.5, 14.2, 14.2, 11.3.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 22"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc4oc([B-]56OC(=O)C(C)(C)[N+]5(C)C(C)(C)C(=O)O6)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC(C)(C)OC(=O)CN1C(=O)CCc2cc(Br)ccc21"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "OPV6-Bot15; tert-butyl 2-(6-(5-(4,8-bis((2-ethylhexyl)oxy)benzo[1,2-b:4,5- b\']dithiophen-2-yl)benzofuran-2-yl)-2-oxo-3,4-dihydroquinolin-1(2H)-yl)acetate"
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc4oc(c5ccc6c(c5)CCC(=O)N6CC(=O)OC(C)(C)C)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 69.2
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'MALDI\', \'hit\': True, \'spectrum\': [ObjectId(\'64d56a573be5587105612f4d\'), ObjectId(\'64d56a583be5587105612f50\'), ObjectId(\'64d56a583be5587105612f52\')], \'notes\': \'HRMS (MALDI) calculated for C49H59NO6S2 [M]+ m/z 821.3784,\\nfound 821.3778.\', \'mass\': 821.3778, \'calculated_mass\': 821.3784, \'formula\': \'C49H59NO6S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d56a583be5587105612f54\'), ObjectId(\'64d56a593be5587105612f56\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.88 (d, J = 1.8 Hz, 1H), 7.72 \342\200\223 7.65 (m, 3H), 7.64 (s, 1H), 7.54 (d, J = 8.5 Hz, 1H), 7.47 (d, J = 5.5 Hz, 1H), 7.36 (d, J = 5.5 Hz, 1H), 6.96 (s, 1H), 6.81 (d, J = 8.4 Hz, 1H), 4.61 (s, 2H), 4.21 (dd, J = 5.6, 2.0 Hz, 4H), 3.02 (dd, J = 8.7, 6.0 Hz, 2H), 2.76 (dd, J = 8.7, 6.0 Hz, 2H), 1.85 (dt, J = 11.9, 5.9 Hz, 2H), 1.74 (dqd, J = 14.1, 7.1, 4.1 Hz, 2H), 1.63 (dtt, J = 17.5, 7.2, 3.5 Hz, 4H), 1.55 (dt, J = 9.9, 5.2 Hz, 2H), 1.47 (s, 9H), 1.46 \342\200\223 1.39 (m, 8H), 1.06 (td, J = 7.4, 4.3 Hz, 6H), 1.00 \342\200\223 0.95 (m, 6H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d56a593be5587105612f5a\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 170.2, 167.5, 156.3, 154.8, 144.4, 144.3, 143.9, 140.0, 132.6, 131.4, 130.2, 129.9, 129.7, 129.1, 126.7, 125.7, 125.0, 124.5, 124.3, 123.1, 120.4, 118.7, 115.1, 114.6, 111.4, 100.7, 82.3, 76.0, 44.9, 40.7, 40.6, 31.3, 30.5, 30.4, 29.2, 29.2, 28.0, 27.9, 25.4, 23.9, 23.8, 23.2, 23.1, 14.2, 14.2, 11.3.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 23"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc([B-]34OC(=O)C[N+]3(C)CC(=O)O4)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "O=C(O)C=Cc1ccc(Br)c(F)c1"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(c3ccc(C=CC(=O)O)cc3F)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 8.4
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(-)\', \'hit\': True, \'spectrum\': [ObjectId(\'64d69f453be5587105612f6b\'), ObjectId(\'64d69f453be5587105612f6d\')], \'notes\': \'HRMS (ESI-) calculated for C35H42FO4S2 [M-H]- m/z 609.2509, found 609.2496.\', \'mass\': 609.2496, \'calculated_mass\': 609.2509, \'formula\': \'C35H42FO4S2\', \'ionized_product\': \'[M-H]-\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d69f463be5587105612f6f\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.97 (s, 1H), 7.75 \342\200\223 7.69 (m, 2H), 7.47 (d, J = 5.3 Hz, 1H), 7.41 \342\200\223 7.35 (m, 3H), 7.23 \342\200\223 6.98 (m, 1H), 6.48 (d, J = 15.9 Hz, 1H), 4.21 (dd, J = 9.5, 5.4 Hz, 4H), 1.83 (q, J = 6.0 Hz, 2H), 1.73 (dtd, J = 14.0, 7.2, 3.6 Hz, 4H), 1.62 (dddt, J = 13.8, 11.3, 7.1, 3.5 Hz, 4H), 1.41 (qd, J = 7.2, 6.2, 3.1 Hz, 8H), 1.04 (td, J = 7.5, 3.8 Hz, 6H), 0.96 (d, J = 6.7 Hz, 6H). \'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d69f463be5587105612f76\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 170.5, 160.7, 158.7, 147.9, 145.8, 145.1, 144.4, 144.2, 135.7, 135.4, 135.4, 133.6, 133.5, 132.3, 132.2, 132.0, 131.9, 130.3, 130.0, 129.7, 129.0, 126.5, 126.2, 126.1, 124.7, 124.3, 124.3, 121.0, 120.9, 120.4, 120.3, 119.0, 115.7, 115.5, 76.2, 76.1, 40.7, 40.7, 37.8, 37.2, 34.2, 30.8, 30.5, 30.4, 29.2, 29.2, 26.8, 26.7, 26.7, 26.6, 26.2, 26.1, 25.9, 25.9, 25.9, 24.1, 23.9, 23.8, 23.1, 22.8, 14.2, 14.1, 11.3, 11.3.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [ObjectId(\'64d69f463be5587105612f78\')], \'notes\': \'19F NMR (471 MHz, CDCl3) \316\264 -111.85.\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 24"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc4oc([B-]56OC(=O)C(C)(C)[N+]5(C)C(C)(C)C(=O)O6)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Fc1ccccc1-c1cc2cc(Br)ccc2[nH]1"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc4oc(c5ccc6[nH]c(-c7ccccc7F)cc6c5)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 15.9
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [ObjectId(\'64d6a2d83be5587105612f7b\')], \'notes\': \'\', \'mass\': 771.3211, \'calculated_mass\': 771.3216, \'formula\': \'C48H50FNO3S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d6a2d93be5587105612f7d\'), ObjectId(\'64d6a2da3be5587105612f84\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 9.01 \342\200\223 8.96 (m, 1H), 8.20 (d, J = 1.5 Hz, 1H), 7.92 (d, J = 1.9 Hz, 1H), 7.82 (td, J = 7.8, 1.9 Hz, 1H), 7.75 (dd, J = 8.5, 1.7 Hz, 1H), 7.69 \342\200\223 7.64 (m, 2H), 7.58 (d, J = 8.4 Hz, 1H), 7.51 \342\200\223 7.46 (m, 2H), 7.36 (d, J = 5.5 Hz, 1H), 7.31 (tdd, J = 7.3, 5.2, 1.9 Hz, 1H), 7.26 \342\200\223 7.18 (m, 2H), 7.02 (d, J = 2.8 Hz, 2H), 4.22 (dd, J = 5.6, 1.9 Hz, 4H), 1.87 (dp, J = 12.0, 6.0 Hz, 2H), 1.79 \342\200\223 1.59 (m, 6H), 1.55 (dddd, J = 11.2, 8.7, 4.7, 2.9 Hz, 2H), 1.49 \342\200\223 1.38 (m, 8H), 1.06 (td, J = 7.4, 4.3 Hz, 6H), 0.97 (td, J = 7.0, 2.4 Hz, 6H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d6a2da3be5587105612f86\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 160.3, 158.6, 158.3, 154.9, 144.4, 144.4, 144.3, 136.9, 133.8, 133.7, 132.7, 131.4, 130.4, 130.2, 129.5, 129.2, 129.2, 129.1, 128.4, 128.0, 128.0, 125.6, 124.9, 124.9, 122.7, 122.6, 120.4, 119.5, 119.4, 118.5, 117.6, 116.7, 116.5, 115.0, 111.5, 111.3, 102.0, 102.0, 99.6, 76.0, 76.0, 40.7, 40.7, 30.5, 30.5, 29.3, 29.2, 23.9, 23.9, 23.2, 23.1, 14.2, 14.2, 11.4.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [ObjectId(\'64d6a2da3be5587105612f88\')], \'notes\': \'19F NMR (471 MHz, CDCl3) \316\264 -117.16.\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 25"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc4oc([B-]56OC(=O)C(C)(C)[N+]5(C)C(C)(C)C(=O)O6)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCOC(=O)c1[nH]c2ccccc2c1Br"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "OPV6-BOT10"
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc4oc(c5c(C(=O)OCC)[nH]c6ccccc65)cc4c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 46.8
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [ObjectId(\'64d6aa5b3be5587105612f8b\')], \'notes\': \'HRMS (EI+) calculated for C45H51NO5S2 [M]+ m/z 749.3209, found 749.3195.\', \'mass\': 749.3195, \'calculated_mass\': 749.3209, \'formula\': \'C45H51NO5S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d6aa5c3be5587105612f8d\'), ObjectId(\'64d6aa5c3be5587105612f8f\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 9.20 (s, 1H), 8.37 (d, J = 8.2 Hz, 1H), 8.00 (d, J = 1.8 Hz, 1H), 7.73 (dd, J = 8.4, 1.9 Hz, 1H), 7.69 (s, 1H), 7.66 \342\200\223 7.62 (m, 2H), 7.49 (d, J = 5.5 Hz, 1H), 7.48 \342\200\223 7.40 (m, 2H), 7.37 (d, J = 5.5 Hz, 1H), 7.30 (ddd, J = 8.0, 6.6, 1.3 Hz, 1H), 4.49 (q, J = 7.1 Hz, 2H), 4.24 (dd, J = 5.6, 2.9 Hz, 4H), 1.87 (dt, J = 12.1, 6.1 Hz, 2H), 1.79 \342\200\223 1.72 (m, 2H), 1.68 \342\200\223 1.53 (m, 6H), 1.48 \342\200\223 1.40 (m, 11H), 1.07 (td, J = 7.5, 4.7 Hz, 6H), 0.98 (td, J = 7.0, 1.9 Hz, 6H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d6aa5d3be5587105612f93\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 161.0, 154.6, 152.0, 144.4, 144.4, 144.2, 135.4, 132.7, 131.4, 130.2, 129.8, 129.4, 129.2, 126.6, 126.3, 125.6, 123.6, 123.4, 123.1, 121.8, 120.4, 119.0, 115.1, 112.6, 111.7, 111.3, 107.0, 76.0, 76.0, 61.4, 40.7, 40.7, 30.5, 30.4, 29.2, 29.2, 23.9, 23.9, 23.2, 23.1, 14.4, 14.2, 14.2, 11.3.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 26"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4cccs4)s3)s1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC(NC(=O)OC(C)(C)C)c1ccc(Br)cc1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "OPV6-Top1"
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CC(NC(=O)OC(C)(C)C)c1ccc(c2ccc(-c3ccc(-c4cccs4)s3)s2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 1.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [ObjectId(\'64d6ae983be5587105612f96\'), ObjectId(\'64d6ae983be5587105612f98\')], \'notes\': \'HRMS (ESI+) calculated for C25H25NO2S3 [M+H]+ m/z 467.1047, found 467.1043.\', \'mass\': 467.1043, \'calculated_mass\': 467.1047, \'formula\': \'C25H25NO2S3\', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d6ae993be5587105612f9a\'), ObjectId(\'64d6ae993be5587105612f9c\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.58 \342\200\223 7.55 (m, 2H), 7.32 (d, J = 7.9 Hz, 2H), 7.24 \342\200\223 7.20 (m, 2H), 7.18 (dd, J = 3.7, 1.1 Hz, 1H), 7.14 (d, J = 3.8 Hz, 1H), 7.10 (d, J = 0.9 Hz, 2H), 7.03 (dd, J = 5.1, 3.6 Hz, 1H), 4.80 (s, 2H), 1.45 (d, J = 19.3 Hz, 12H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d6ae993be5587105612f9f\'), ObjectId(\'64d6ae9a3be5587105612fa1\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 155.1, 143.0, 137.1, 136.3, 136.2, 132.9, 127.9, 126.5, 125.8, 124.5, 124.5, 124.4, 124.2, 123.7, 123.7, 100.9, 47.9, 28.4.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 27"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4cccs4)s3)s1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Brc1cccc([Si](c2ccccc2)(c2ccccc2)c2ccccc2)c1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "OPV6-Top3"
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "c1ccc([Si](c2ccccc2)(c2ccccc2)c2cccc(c3ccc(-c4ccc(-c5cccs5)s4)s3)c2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 10.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [ObjectId(\'64d6b04b3be5587105612fa5\'), ObjectId(\'64d6b04c3be5587105612fa7\')], \'notes\': \'HRMS (ESI+) calculated for C36H26SiS3 [M]+ m/z 582.0966, found 582.0969.\', \'mass\': 582.0969, \'calculated_mass\': 582.0966, \'formula\': \'C36H26SiS3 \', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d6b04c3be5587105612fa9\'), ObjectId(\'64d6b04c3be5587105612fad\')], \'notes\': \'1H NMR (600 MHz, CDCl3) \316\264 7.82 (s, 1H), 7.66 (d, J = 8.0 Hz, 1H), 7.61 (d, J = 7.2 Hz, 6H), 7.51 \342\200\223 7.44 (m, 4H), 7.41 (d, J = 7.8 Hz, 7H), 7.22 (t, J = 4.1 Hz, 1H), 7.18 (d, J = 4.2 Hz, 1H), 7.13 \342\200\223 7.06 (m, 4H), 7.03 (t, J = 4.2 Hz, 1H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d6b04d3be5587105612faf\'), ObjectId(\'64d6b04d3be5587105612fb3\')], \'notes\': \'13C NMR (151 MHz, CDCl3) \316\264 143.2, 137.1, 136.5, 136.4, 136.2, 136.1, 135.7, 135.3, 133.8, 133.4, 133.3, 129.7, 128.5, 128.0, 127.9, 126.9, 124.5, 124.5, 124.3, 124.2, 123.9, 123.7.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 28"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4cccs4)s3)cc1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Cc1cc(Br)c2nnnn2c1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "TMSOK"
+        }
+        identifiers {
+          type: SMILES
+          value: "C[Si](C)(C)[O-].[K+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd P(tBu)3 G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1621274-11-0"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "THF"
+        }
+        identifiers {
+          type: SMILES
+          value: "C1CCOC1"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 60.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "OPV6-Top5"
+  }
+  outcomes {
+    reaction_time {
+      value: 1.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1cc(c2ccc(-c3ccc(-c4cccs4)s3)cc2)c2nnnn2c1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 2.6
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [ObjectId(\'64d6b3073be5587105612fb6\'), ObjectId(\'64d6b3073be5587105612fb8\')], \'notes\': \'HRMS (ESI+) calculated for C20H15N4S2 [M+H]+ m/z 375.0738, found 375.0733.\', \'mass\': 375.0733, \'calculated_mass\': 375.0738, \'formula\': \'C20H15N4S2\', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d6b3083be5587105612fba\'), ObjectId(\'64d6b3083be5587105612fbc\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 8.58 (t, J = 1.3 Hz, 1H), 8.23 \342\200\223 8.18 (m, 2H), 7.80 \342\200\223 7.75 (m, 2H), 7.70 (d, J = 1.4 Hz, 1H), 7.35 (d, J = 3.8 Hz, 1H), 7.25 (dd, J = 5.5, 4.0 Hz, 2H), 7.19 (d, J = 3.8 Hz, 1H), 7.05 (dd, J = 5.1, 3.6 Hz, 1H), 2.56 (d, J = 1.2 Hz, 3H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d6b3083be5587105612fc0\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 147.0, 141.9, 137.6, 137.2, 135.3, 132.3, 131.1, 129.0, 128.0, 127.9, 127.4, 125.9, 124.8, 124.7, 124.6, 123.9, 121.4, 18.3.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 29"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4cccs4)s3)cc1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Brc1cn(C(c2ccccc2)(c2ccccc2)c2ccccc2)cn1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "OPV6-Top7"
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "c1ccc(C(c2ccccc2)(c2ccccc2)n2cnc(c3ccc(-c4ccc(-c5cccs5)s4)cc3)c2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 26.0
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'EI\', \'hit\': True, \'spectrum\': [ObjectId(\'64d6b4e13be5587105612fc3\'), ObjectId(\'64d6b4e13be5587105612fc5\')], \'notes\': \'HRMS (EI+) calculated for C36H26N2S2 [M]+ m/z 550.1537, found 550.1527.\', \'mass\': 550.1527, \'calculated_mass\': 550.1537, \'formula\': \'C36H26N2S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d6b4e23be5587105612fc7\'), ObjectId(\'64d6b4e23be5587105612fcc\'), ObjectId(\'64d6b4e33be5587105612fcf\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.79 \342\200\223 7.72 (m, 2H), 7.61 \342\200\223 7.56 (m, 3H), 7.39 \342\200\223 7.35 (m, 9H), 7.23 \342\200\223 7.19 (m, 9H), 7.16 (d, J = 1.4 Hz, 1H), 7.14 (d, J = 3.8 Hz, 1H), 7.02 (dd, J = 5.1, 3.6 Hz, 1H)\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d6b4e33be5587105612fd1\'), ObjectId(\'64d6b4e33be5587105612fd4\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 143.1, 142.1, 140.0, 139.2, 137.5, 136.5, 135.4, 132.6, 129.8, 129.0, 128.3, 128.2, 127.9, 127.3, 127.0, 126.0, 125.8, 125.6, 125.3, 124.7, 124.6, 124.3, 123.8, 123.7, 123.6, 123.5, 117.6, 83.9, 75.8.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 30"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4cccs4)s3)cc1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC(C)(C)OC(=O)n1ccc2ccc(Br)cc21"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "OPV6-Top8"
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CC(C)(C)OC(=O)n1ccc2ccc(c3ccc(-c4ccc(-c5cccs5)s4)cc3)cc21"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 5.7
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [ObjectId(\'64d6bdd63be5587105612fd7\')], \'notes\': \'HRMS (ESI+) calculated for C27H23NO2S2 [M]+ m/z 457.1170, found 457.1161.\', \'mass\': 457.1161, \'calculated_mass\': 457.117, \'formula\': \'C27H23NO2S2\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d6bdd63be5587105612fd9\'), ObjectId(\'64d6bdd63be5587105612fdb\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 8.48 (s, 1H), 7.76 \342\200\223 7.60 (m, 6H), 7.52 (dd, J = 8.1, 1.8 Hz, 1H), 7.28 (d, J = 3.9 Hz, 1H), 7.23 (t, J = 4.4 Hz, 2H), 7.17 (dd, J = 3.9, 1.7 Hz, 1H), 7.04 (dd, J = 5.1, 3.4 Hz, 1H), 6.60 (d, J = 3.7 Hz, 1H), 1.70 (s, 9H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d6bdd73be5587105612fdf\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 149.7, 142.9, 141.0, 137.5, 136.8, 136.6, 135.8, 135.4, 132.7, 129.9, 127.9, 127.8, 126.5, 126.0, 125.9, 124.7, 124.4, 123.6, 123.6, 121.9, 121.2, 113.7, 107.1, 83.8, 28.2, 24.9. \'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 31"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4cccs4)s3)cc1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Cc1ccc(I)cc1Cc1ccc(-c2ccc(F)cc2)s1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "OPV6-Top11"
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(c2ccc(-c3ccc(-c4cccs4)s3)cc2)cc1Cc1ccc(-c2ccc(F)cc2)s1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 21.2
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'MALDI\', \'hit\': True, \'spectrum\': [ObjectId(\'64d6bf373be5587105612fe2\')], \'notes\': \'HRMS (MALDI) calculated for C32H23FS3 [M]+ m/z 522.0946, found 522.0940.\', \'mass\': 522.094, \'calculated_mass\': 522.0946, \'formula\': \'C32H23FS3\', \'ionized_product\': \'[M]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d6bf383be5587105612fe4\'), ObjectId(\'64d6bf383be5587105612feb\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.67 \342\200\223 7.64 (m, 2H), 7.63 \342\200\223 7.59 (m, 2H), 7.51 \342\200\223 7.44 (m, 4H), 7.28 (s, 1H), 7.25 (s, 1H), 7.24 \342\200\223 7.20 (m, 2H), 7.16 (d, J = 3.8 Hz, 1H), 7.06 \342\200\223 7.00 (m, 4H), 6.72 (dd, J = 3.0, 1.9 Hz, 1H), 4.20 (s, 2H), 2.38 (s, 3H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d6bf393be5587105612fed\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 163.1, 161.1, 143.2, 142.8, 141.6, 140.0, 138.7, 138.4, 137.4, 136.7, 135.8, 132.8, 131.0, 130.8, 130.8, 128.0, 127.9, 127.4, 127.3, 127.2, 127.1, 126.0, 125.9, 125.3, 124.7, 124.4, 123.7, 123.6, 122.7, 115.8, 115.6, 34.3, 19.2. \'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [ObjectId(\'64d6bf393be5587105612fef\')], \'notes\': \'19F NMR (471 MHz, CDCl3) \316\264 -115.18. \'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 32"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4cccs4)s3)cc1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC(C)(C)OC(=O)N1CCc2nc(Br)sc2C1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  notes {
+    procedure_details: "OPV6-Top14"
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CC(C)(C)OC(=O)N1CCc2nc(c3ccc(-c4ccc(-c5cccs5)s4)cc3)sc2C1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 13
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}, {\'method\': \'MPLC\', \'loading_method\': \' \', \'column_type\': \' \', \'flow_rate\': 0.0, \'solvent_1\': \' \', \'solvent_2\': \' \', \'uv_vis_spectrum\': [], \'MPLC_method\': \'{\"start\":{\"0\":null},\"end\":{\"0\":null},\"volume\":{\"0\":null}}\', \'characterization\': [{\'purification_step\': 1, \'elution_volume\': 0, \'hit_product\': None, \'hit_boron\': None, \'hit_halide\': None, \'hit_degrade\': None, \'MS\': {\'ionization_method\': \'ESI(+)\', \'hit\': True, \'spectrum\': [ObjectId(\'64d6c07f3be5587105612ff2\')], \'notes\': \'HRMS (ESI+) calculated for C25H25N2O2S3 [M+H]+ m/z 481.1078, found 481.1067. \', \'mass\': 481.1067, \'calculated_mass\': 481.1078, \'formula\': \' C25H25N2O2S3\', \'ionized_product\': \'[M+H]+\'}, \'H-NMR\': {\'spectrum\': [ObjectId(\'64d6c0803be5587105612ff4\'), ObjectId(\'64d6c0803be5587105612ff6\')], \'notes\': \'1H NMR (500 MHz, CDCl3) \316\264 7.90 (d, J = 8.5 Hz, 2H), 7.66 \342\200\223 7.63 (m, 2H), 7.30 (d, J = 3.8 Hz, 1H), 7.24 (dd, J = 5.1, 1.1 Hz, 1H), 7.22 (dd, J = 3.6, 1.1 Hz, 1H), 7.17 (d, J = 3.8 Hz, 1H), 7.04 (dd, J = 5.1, 3.6 Hz, 1H), 4.69 (s, 2H), 3.79 (s, 2H), 2.95 (s, 2H), 1.51 (s, 9H).\'}, \'C-NMR\': {\'spectrum\': [ObjectId(\'64d6c0813be5587105612ffa\')], \'notes\': \'13C NMR (126 MHz, CDCl3) \316\264 165.4, 142.0, 137.5, 137.2, 135.5, 132.5, 127.9, 126.8, 125.8, 124.7, 124.6, 124.4, 123.9, 80.4, 31.9, 29.7, 29.4, 28.4, 28.4, 22.7, 14.1.\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}], \'solvents\': []}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 33"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1(C)C(=O)O[B-]2(c3cc4sc(-c5ccc(-c6cccs6)s5)cc4s3)OC(=O)C(C)(C)[N+]21C"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Cc1cc(N2CCN(C)CC2)ncc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1cc(N2CCN(C)CC2)ncc1-c1cc2sc(-c3ccc(-c4cccs4)s3)cc2s1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 2
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 34"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1(C)C(=O)O[B-]2(c3cc4sc(-c5ccc(-c6cccs6)s5)cc4s3)OC(=O)C(C)(C)[N+]21C"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Cc1ccc(NC(=O)OC(C)(C)C)cc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1ccc(NC(=O)OC(C)(C)C)cc1-c1cc2sc(-c3ccc(-c4cccs4)s3)cc2s1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 10
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 35"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1(C)C(=O)O[B-]2(c3cc4sc(-c5ccc(-c6cccs6)s5)cc4s3)OC(=O)C(C)(C)[N+]21C"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC(C)(C)c1ccc(-c2ccc(C(C)(C)C)cc2Br)cc1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CC(C)(C)c1ccc(-c2ccc(C(C)(C)C)cc2-c2cc3sc(-c4ccc(-c5cccs5)s4)cc3s2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 5.2
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 36"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1ccc(-c3ccc(-c4ccc(-c5cccs5)s4)s3)s1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Cc1cc(N2CCN(C)CC2)ncc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "Cc1cc(N2CCN(C)CC2)ncc1-c1ccc(-c2ccc(-c3ccc(-c4cccs4)s3)s2)s1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 1
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 37"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1(C)C(=O)O[B-]2(c3cccc(-c4ccc(-c5cccs5)s4)c3)OC(=O)C(C)(C)[N+]21C"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "COc1ccc(CNc2ccc([N+](=O)[O-])cc2Br)cc1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "COc1ccc(CNc2ccc([N+](=O)[O-])cc2-c2cccc(-c3ccc(-c4cccs4)s3)c2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 22.5
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 38"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc([B-]45OC(=O)C[N+]4(C)CC(=O)O5)[se]3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "N#Cc1csc(Br)n1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc(-c4nc(C#N)cs4)[se]3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 27.8
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 39"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3ccc(-c4ccc([B-]56OC(=O)C[N+]5(C)CC(=O)O6)s4)s3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "COc1ccc(-c2csc(C)n2)cc1Br"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3ccc(-c4ccc(-c5cc(-c6csc(C)n6)ccc5OC)s4)s3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 28
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 40"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCC(CC)COc1c2cc(-c3cccc([B-]45OC(=O)C[N+]4(C)CC(=O)O5)c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "Brc1c2ccccc2c(-c2cccc3ccccc23)c2ccccc12"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCC(CC)COc1c2cc(-c3cccc(-c4c5ccccc5c(-c5cccc6ccccc56)c5ccccc45)c3)sc2c(OCC(CC)CCCC)c2ccsc12"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 24.4
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 41"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "C[N+]12CC(=O)O[B-]1(c1cccc(-c3cccs3)c1)OC(=O)C2"
+        }
+        amount {
+          moles {
+            value: 0.3
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CCCCCCCCCc1ccc(Br)cc1"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CCCCCCCCCc1ccc(-c2cccc(-c3cccs3)c2)cc1"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 15
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 42"
+}
+reactions {
+  inputs {
+    key: "Input 1"
+    value {
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC1(C)OB(c2ccc(-c3cccs3)s2)OC1(C)C"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: SMILES
+          value: "CC(C)(C)OC(=O)CN1C(=O)CCc2cc(Br)ccc21"
+        }
+        amount {
+          moles {
+            value: 0.1
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REACTANT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Na2CO3"
+        }
+        identifiers {
+          type: SMILES
+          value: "O=C([O-])[O-].[Na+].[Na+]"
+        }
+        amount {
+          moles {
+            value: 1.0
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: REAGENT
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "Pd XPhos G4"
+        }
+        identifiers {
+          type: CAS_NUMBER
+          value: "1599466-81-5"
+        }
+        amount {
+          moles {
+            value: 0.01
+            units: MILLIMOLE
+          }
+        }
+        reaction_role: CATALYST
+      }
+      components {
+        identifiers {
+          type: NAME
+          value: "5:1 dioxane:water"
+        }
+        identifiers {
+          type: SMILES
+          value: "O1CCOCC1.O"
+        }
+        amount {
+          volume {
+            value: 8.0
+            units: MILLILITER
+          }
+        }
+        reaction_role: SOLVENT
+      }
+      addition_order: 1
+      addition_device {
+        type: CUSTOM
+        details: "MMLI Burke Automated Synthesizer"
+      }
+    }
+  }
+  setup {
+    vessel {
+      type: VIAL
+      material {
+        type: GLASS
+      }
+      volume {
+        value: 40.0
+        units: MILLILITER
+      }
+    }
+  }
+  conditions {
+    temperature {
+      control {
+        type: DRY_ALUMINUM_PLATE
+      }
+      setpoint {
+        value: 100.0
+        units: CELSIUS
+      }
+    }
+    pressure {
+      atmosphere {
+        type: NITROGEN
+      }
+    }
+    stirring {
+      type: STIR_BAR
+      rate {
+        type: MEDIUM
+      }
+    }
+    illumination {
+      type: AMBIENT
+    }
+    reflux: false
+    conditions_are_dynamic: false
+  }
+  outcomes {
+    reaction_time {
+      value: 12.0
+      units: HOUR
+    }
+    products {
+      identifiers {
+        type: SMILES
+        value: "CC(C)(C)OC(=O)CN1C(=O)CCc2cc(-c3ccc(-c4cccs4)s3)ccc21"
+      }
+      is_desired_product: true
+      measurements {
+        type: YIELD
+        amount {
+          mass {
+            value: 8
+            units: MILLIGRAM
+          }
+        }
+      }
+      features {
+        key: "Reaction Note / Purification / Characterization"
+        value {
+          string_value: "[{\'method\': \'Raw product\', \'characterization\': [{\'MS\': {\'ionization_method\': \' \', \'hit\': False, \'spectrum\': [], \'notes\': \'\', \'mass\': 0.0, \'calculated_mass\': 0.0, \'formula\': \'\', \'ionized_product\': \' \'}, \'H-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'C-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'B-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'F-NMR\': {\'spectrum\': [], \'notes\': \'\'}, \'observations\': \'\'}]}]"
+          description: "Reaction Notes\nPurification JSON"
+        }
+      }
+      reaction_role: PRODUCT
+    }
+  }
+  provenance {
+    experimenter {
+      name: "MMLI Thrust 4 Team"
+      organization: "Molecule Maker Lab Institute"
+      email: "ORD-Feedback@moleculemaker.org"
+    }
+    city: "Urbana, IL"
+    doi: "10.1038/s41586-024-07892-1"
+    publication_url: "https://www.nature.com/articles/s41586-024-07892-1"
+    record_created {
+      time {
+        value: "2025-04-30T17:32:53"
+      }
+      person {
+        name: "MMLI Thrust 4 Team"
+        organization: "Molecule Maker Lab Institute"
+        email: "ORD-Feedback@moleculemaker.org"
+      }
+    }
+  }
+  reaction_id: "Reaction 43"
+}


### PR DESCRIPTION
Hi Ben, this is Weiqi Zhang. We had a meeting about exporting Suzuki-coupling reaction data last month. Here's the dataset and the template.

The attempts_dataset.pbtxt file contains all the Suzuki-coupling reactions from the paper https://www.nature.com/articles/s41586-024-07892-1.
[template+data.zip](https://github.com/user-attachments/files/20417959/template%2Bdata.zip)
