### PR TITLE
Mirror dataset to Hugging Face to reduce Git LFS load

### DIFF
--- a/.github/workflows/huggingface_mirror.yml
+++ b/.github/workflows/huggingface_mirror.yml
@@ -1,8 +1,12 @@
-# Mirrors new/changed dataset files to the Hugging Face dataset
-# open-reaction-database/ord-data after each push to main.
+# Mirrors dataset changes to the Hugging Face dataset
+# open-reaction-database/ord-data.
+#
+# - Push to `main`: commits the changes to the mirror.
+# - Pull requests touching `data/**` or the mirror tooling: dry-run that
+#   posts the planned uploads/deletions to the job summary.
 #
 # Requires an `HF_TOKEN` repository secret with write access to the
-# Hugging Face dataset.
+# Hugging Face dataset (only used on the push-to-main path).
 
 name: Hugging Face Mirror
 
@@ -10,58 +14,60 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      - 'data/**'
+      - '.github/workflows/huggingface_mirror.yml'
+      - 'scripts/upload_to_huggingface.py'
+      - 'scripts/requirements.txt'
 
 jobs:
   mirror:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout ord-data (no LFS smudge)
-      uses: actions/checkout@v4
+    - uses: actions/checkout@v4
       with:
-        fetch-depth: 2
+        fetch-depth: 0
         lfs: false
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
       env:
         GIT_LFS_SKIP_SMUDGE: 1
-    - name: Identify changed data files
-      id: changed
+
+    - id: range
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PUSH_BEFORE: ${{ github.event.before }}
+        PUSH_AFTER: ${{ github.sha }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        cd "${GITHUB_WORKSPACE}"
-        # On the first push to a branch, HEAD^ may not exist; fall back to HEAD.
-        if git rev-parse HEAD^ >/dev/null 2>&1; then
-          BASE="HEAD^"
+        EMPTY_TREE="$(git hash-object -t tree /dev/null)"
+        if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+          BASE="${PR_BASE_SHA}"; HEAD="${PR_HEAD_SHA}"
         else
-          BASE="HEAD"
+          BASE="${PUSH_BEFORE}"; HEAD="${PUSH_AFTER}"
+          if [[ -z "${BASE}" || "${BASE}" == "0000000000000000000000000000000000000000" ]]; then
+            BASE="${EMPTY_TREE}"
+          fi
         fi
-        git diff --name-only --diff-filter=ACMR "${BASE}" HEAD -- 'data/**' \
-          > changed_data_files.txt || true
-        NUM_CHANGED="$(wc -l < changed_data_files.txt | tr -d ' ')"
-        echo "num_changed=${NUM_CHANGED}" >> "${GITHUB_OUTPUT}"
-        echo "Found ${NUM_CHANGED} changed data files"
-        cat changed_data_files.txt
-    - name: Fetch LFS objects for changed files only
-      if: steps.changed.outputs.num_changed != '0'
-      run: |
-        cd "${GITHUB_WORKSPACE}"
-        # --include takes a comma-separated list of path patterns.
-        INCLUDE="$(paste -sd, changed_data_files.txt)"
-        git lfs pull --include="${INCLUDE}"
-    - name: Set up Python
-      if: steps.changed.outputs.num_changed != '0'
-      uses: actions/setup-python@v5
+        echo "base=${BASE}" >> "${GITHUB_OUTPUT}"
+        echo "head=${HEAD}" >> "${GITHUB_OUTPUT}"
+        echo "Diff range: ${BASE}..${HEAD}"
+
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    - name: Install huggingface_hub
-      if: steps.changed.outputs.num_changed != '0'
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r scripts/requirements.txt
-    - name: Upload changed files to Hugging Face
-      if: steps.changed.outputs.num_changed != '0'
+
+    - run: pip install -r scripts/requirements.txt
+
+    - name: Mirror to Hugging Face
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        GITHUB_SHA: ${{ github.sha }}
+        DRY_RUN_FLAG: ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
       run: |
-        cd "${GITHUB_WORKSPACE}"
         python scripts/upload_to_huggingface.py \
-          --files-from=changed_data_files.txt \
-          --commit-message="Mirror ${GITHUB_SHA::7} from github.com/${GITHUB_REPOSITORY}"
+          --base="${{ steps.range.outputs.base }}" \
+          --head="${{ steps.range.outputs.head }}" \
+          --commit-message="Mirror ${GITHUB_SHA::7} from github.com/${GITHUB_REPOSITORY}" \
+          --summary-file="${GITHUB_STEP_SUMMARY}" \
+          ${DRY_RUN_FLAG}

--- a/.github/workflows/huggingface_mirror.yml
+++ b/.github/workflows/huggingface_mirror.yml
@@ -1,0 +1,67 @@
+# Mirrors new/changed dataset files to the Hugging Face dataset
+# open-reaction-database/ord-data after each push to main.
+#
+# Requires an `HF_TOKEN` repository secret with write access to the
+# Hugging Face dataset.
+
+name: Hugging Face Mirror
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout ord-data (no LFS smudge)
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+        lfs: false
+      env:
+        GIT_LFS_SKIP_SMUDGE: 1
+    - name: Identify changed data files
+      id: changed
+      run: |
+        cd "${GITHUB_WORKSPACE}"
+        # On the first push to a branch, HEAD^ may not exist; fall back to HEAD.
+        if git rev-parse HEAD^ >/dev/null 2>&1; then
+          BASE="HEAD^"
+        else
+          BASE="HEAD"
+        fi
+        git diff --name-only --diff-filter=ACMR "${BASE}" HEAD -- 'data/**' \
+          > changed_data_files.txt || true
+        NUM_CHANGED="$(wc -l < changed_data_files.txt | tr -d ' ')"
+        echo "num_changed=${NUM_CHANGED}" >> "${GITHUB_OUTPUT}"
+        echo "Found ${NUM_CHANGED} changed data files"
+        cat changed_data_files.txt
+    - name: Fetch LFS objects for changed files only
+      if: steps.changed.outputs.num_changed != '0'
+      run: |
+        cd "${GITHUB_WORKSPACE}"
+        # --include takes a comma-separated list of path patterns.
+        INCLUDE="$(paste -sd, changed_data_files.txt)"
+        git lfs pull --include="${INCLUDE}"
+    - name: Set up Python
+      if: steps.changed.outputs.num_changed != '0'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install huggingface_hub
+      if: steps.changed.outputs.num_changed != '0'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r scripts/requirements.txt
+    - name: Upload changed files to Hugging Face
+      if: steps.changed.outputs.num_changed != '0'
+      env:
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        GITHUB_SHA: ${{ github.sha }}
+      run: |
+        cd "${GITHUB_WORKSPACE}"
+        python scripts/upload_to_huggingface.py \
+          --files-from=changed_data_files.txt \
+          --commit-message="Mirror ${GITHUB_SHA::7} from github.com/${GITHUB_REPOSITORY}"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,40 @@
 ![](https://raw.githubusercontent.com/Open-Reaction-Database/ord-data/main/badges/reactions.svg)
 [![DOI](https://zenodo.org/badge/283813042.svg)](https://zenodo.org/badge/latestdoi/283813042)
 
-## Cloning with Git LFS
+## Getting the Data
 
-We use [Git LFS](https://git-lfs.github.com) to efficiently store
-the Dataset records that make up the ORD. To view these files locally, you'll
-need to install Git LFS before cloning the repository.
+**We recommend downloading the dataset from
+[Hugging Face](https://huggingface.co/datasets/open-reaction-database/ord-data)
+instead of cloning this repository with Git LFS.** GitHub LFS bandwidth is a
+shared, limited resource, and heavy cloning traffic can exhaust our monthly
+quota and block downloads for everyone. The Hugging Face mirror has no such
+limit.
+
+### Option 1 (recommended): Download from Hugging Face
+
+```bash
+pip install -r scripts/requirements.txt
+python scripts/download_from_huggingface.py
+```
+
+The script mirrors the `data/` directory from the Hugging Face dataset into
+your local checkout. Pass `--allow-pattern 'data/4d/*.pb.gz'` (repeatable) to
+download only a subset, or `--output-dir <path>` to write somewhere other
+than the repository root. If you don't need the Git history, you can also
+clone this repo *without* LFS objects and then run the script:
+
+```bash
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/open-reaction-database/ord-data.git
+cd ord-data
+python scripts/download_from_huggingface.py
+```
+
+### Option 2: Clone with Git LFS
+
+If you have access to Git LFS bandwidth and need the `.pb.gz` files in place
+as part of a normal clone, install [Git LFS](https://git-lfs.github.com)
+before cloning. Please prefer Option 1 when possible so we don't exhaust the
+shared LFS quota.
 
 ## Data Manipulation
 

--- a/scripts/download_from_huggingface.py
+++ b/scripts/download_from_huggingface.py
@@ -6,7 +6,7 @@ directory from the Hugging Face dataset at
 https://huggingface.co/datasets/open-reaction-database/ord-data.
 
 Usage:
-    pip install huggingface_hub
+    pip install -r scripts/requirements.txt
     python scripts/download_from_huggingface.py
 
 Optional flags let you restrict the download to a subset of files or
@@ -19,6 +19,7 @@ from pathlib import Path
 from huggingface_hub import snapshot_download
 
 HF_REPO_ID = "open-reaction-database/ord-data"
+DEFAULT_ALLOW_PATTERNS = ["data/**"]
 
 
 def main() -> None:
@@ -40,18 +41,20 @@ def main() -> None:
         default=None,
         help=(
             "Glob pattern(s) of files to include (repeatable). "
+            f"Default: {DEFAULT_ALLOW_PATTERNS}. "
             "Example: --allow-pattern 'data/4d/*.pb.gz'"
         ),
     )
     args = parser.parse_args()
 
+    allow_patterns = args.allow_pattern or DEFAULT_ALLOW_PATTERNS
     args.output_dir.mkdir(parents=True, exist_ok=True)
     local_dir = snapshot_download(
         repo_id=HF_REPO_ID,
         repo_type="dataset",
         revision=args.revision,
         local_dir=str(args.output_dir),
-        allow_patterns=args.allow_pattern,
+        allow_patterns=allow_patterns,
     )
     print(f"Downloaded {HF_REPO_ID}@{args.revision} to {local_dir}")
 

--- a/scripts/download_from_huggingface.py
+++ b/scripts/download_from_huggingface.py
@@ -1,0 +1,60 @@
+"""Download ord-data dataset files from Hugging Face.
+
+Use this as an alternative to `git lfs pull` when Git LFS bandwidth is
+unavailable or exhausted. The script mirrors the repository's `data/`
+directory from the Hugging Face dataset at
+https://huggingface.co/datasets/open-reaction-database/ord-data.
+
+Usage:
+    pip install huggingface_hub
+    python scripts/download_from_huggingface.py
+
+Optional flags let you restrict the download to a subset of files or
+target a different local directory.
+"""
+
+import argparse
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+HF_REPO_ID = "open-reaction-database/ord-data"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Local directory to mirror the dataset into (default: repo root).",
+    )
+    parser.add_argument(
+        "--revision",
+        default="main",
+        help="Branch, tag, or commit SHA to download (default: main).",
+    )
+    parser.add_argument(
+        "--allow-pattern",
+        action="append",
+        default=None,
+        help=(
+            "Glob pattern(s) of files to include (repeatable). "
+            "Example: --allow-pattern 'data/4d/*.pb.gz'"
+        ),
+    )
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    local_dir = snapshot_download(
+        repo_id=HF_REPO_ID,
+        repo_type="dataset",
+        revision=args.revision,
+        local_dir=str(args.output_dir),
+        allow_patterns=args.allow_pattern,
+    )
+    print(f"Downloaded {HF_REPO_ID}@{args.revision} to {local_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+huggingface_hub>=0.24

--- a/scripts/upload_to_huggingface.py
+++ b/scripts/upload_to_huggingface.py
@@ -1,10 +1,12 @@
-"""Upload ord-data dataset files to the Hugging Face mirror.
+"""Mirror ord-data changes to the Hugging Face dataset.
 
-Reads a newline-delimited list of repo-relative paths from a file (one
-per line) and uploads them as a single commit to the Hugging Face
-dataset at https://huggingface.co/datasets/open-reaction-database/ord-data.
+Runs `git diff --name-status` between two SHAs, classifies entries into
+uploads and deletions, fetches only the needed LFS objects, and applies
+the changes as a single commit on the Hugging Face dataset at
+https://huggingface.co/datasets/open-reaction-database/ord-data.
 
-Authentication uses the HF_TOKEN environment variable.
+Authentication uses the HF_TOKEN environment variable (not required in
+`--dry-run` mode).
 
 This script is invoked from `.github/workflows/huggingface_mirror.yml`;
 it can also be run locally for manual backfills.
@@ -12,71 +14,150 @@ it can also be run locally for manual backfills.
 
 import argparse
 import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
-from huggingface_hub import CommitOperationAdd, HfApi
+from huggingface_hub import CommitOperationAdd, CommitOperationDelete, HfApi
 
 HF_REPO_ID = "open-reaction-database/ord-data"
+DATA_PATHSPEC = "data/**"
+
+
+@dataclass
+class DiffPlan:
+    uploads: list[str] = field(default_factory=list)
+    deletions: list[str] = field(default_factory=list)
+
+
+def parse_name_status(diff_text: str) -> DiffPlan:
+    """Parse `git diff --name-status --find-renames` output.
+
+    Added/Modified entries become uploads. Copies upload the destination.
+    Deletions become deletions. Renames split into delete(old) + upload(new).
+    """
+    plan = DiffPlan()
+    for raw in diff_text.splitlines():
+        line = raw.rstrip("\n")
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        code = parts[0][0]
+        if code in ("A", "M"):
+            plan.uploads.append(parts[1])
+        elif code == "D":
+            plan.deletions.append(parts[1])
+        elif code == "R":
+            plan.deletions.append(parts[1])
+            plan.uploads.append(parts[2])
+        elif code == "C":
+            plan.uploads.append(parts[2])
+        else:
+            print(f"Skipping unrecognized status line: {line!r}", file=sys.stderr)
+    return plan
+
+
+def compute_plan(base: str, head: str, repo_root: Path) -> DiffPlan:
+    diff = subprocess.run(
+        [
+            "git", "diff", "--name-status", "--find-renames",
+            "--diff-filter=ACMRD", base, head, "--", DATA_PATHSPEC,
+        ],
+        cwd=repo_root, check=True, capture_output=True, text=True,
+    )
+    return parse_name_status(diff.stdout)
+
+
+def write_summary(plan: DiffPlan, path: Path | None) -> None:
+    if path is None:
+        return
+    lines = [
+        f"## Hugging Face mirror plan ({HF_REPO_ID})",
+        "",
+        f"- Uploads: **{len(plan.uploads)}**",
+        f"- Deletions: **{len(plan.deletions)}**",
+    ]
+    if plan.uploads:
+        lines += ["", "### Uploads", "", "```", *plan.uploads, "```"]
+    if plan.deletions:
+        lines += ["", "### Deletions", "", "```", *plan.deletions, "```"]
+    # Append rather than overwrite so it plays well with $GITHUB_STEP_SUMMARY.
+    with path.open("a") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def lfs_pull(paths: list[str], repo_root: Path) -> None:
+    if not paths:
+        return
+    subprocess.run(
+        ["git", "lfs", "pull", "--include", ",".join(paths)],
+        cwd=repo_root, check=True,
+    )
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="Base git ref/SHA.")
+    parser.add_argument("--head", required=True, help="Head git ref/SHA.")
     parser.add_argument(
-        "--files-from",
-        type=Path,
-        required=True,
-        help="File containing newline-delimited repo-relative paths to upload.",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
+        "--repo-root", type=Path,
         default=Path(__file__).resolve().parent.parent,
-        help="Local repository root (default: parent of scripts/).",
     )
     parser.add_argument(
-        "--commit-message",
-        default="Mirror update from GitHub",
-        help="Commit message for the Hugging Face commit.",
+        "--commit-message", default="Mirror update from GitHub",
     )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the plan and exit without fetching LFS or contacting HF.",
+    )
+    parser.add_argument("--summary-file", type=Path, default=None)
     args = parser.parse_args()
+
+    plan = compute_plan(args.base, args.head, args.repo_root)
+
+    print(f"Planned uploads ({len(plan.uploads)}):")
+    for p in plan.uploads:
+        print(f"  + {p}")
+    print(f"Planned deletions ({len(plan.deletions)}):")
+    for p in plan.deletions:
+        print(f"  - {p}")
+    write_summary(plan, args.summary_file)
+
+    if not plan.uploads and not plan.deletions:
+        print("Nothing to mirror.")
+        return
+    if args.dry_run:
+        print("Dry run: not fetching LFS or contacting Hugging Face.")
+        return
 
     token = os.environ.get("HF_TOKEN")
     if not token:
         raise SystemExit("HF_TOKEN environment variable is not set.")
 
-    paths = [
-        line.strip()
-        for line in args.files_from.read_text().splitlines()
-        if line.strip()
-    ]
-    if not paths:
-        print("No files to upload.")
-        return
+    lfs_pull(plan.uploads, args.repo_root)
 
-    operations = []
-    for path in paths:
+    operations: list[CommitOperationAdd | CommitOperationDelete] = []
+    for path in plan.uploads:
         local_path = args.repo_root / path
         if not local_path.exists():
-            # File was deleted in this commit range; skip (deletions are
-            # not mirrored automatically — handle those manually if needed).
-            print(f"Skipping missing file: {path}")
-            continue
+            raise SystemExit(f"Expected upload target {local_path} missing after LFS pull.")
         operations.append(
             CommitOperationAdd(path_in_repo=path, path_or_fileobj=str(local_path))
         )
+    for path in plan.deletions:
+        operations.append(CommitOperationDelete(path_in_repo=path))
 
-    if not operations:
-        print("No existing files to upload.")
-        return
-
-    api = HfApi(token=token)
-    api.create_commit(
+    HfApi(token=token).create_commit(
         repo_id=HF_REPO_ID,
         repo_type="dataset",
         operations=operations,
         commit_message=args.commit_message,
     )
-    print(f"Uploaded {len(operations)} file(s) to {HF_REPO_ID}.")
+    print(
+        f"Mirrored {len(plan.uploads)} upload(s) and "
+        f"{len(plan.deletions)} deletion(s) to {HF_REPO_ID}."
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/upload_to_huggingface.py
+++ b/scripts/upload_to_huggingface.py
@@ -1,0 +1,83 @@
+"""Upload ord-data dataset files to the Hugging Face mirror.
+
+Reads a newline-delimited list of repo-relative paths from a file (one
+per line) and uploads them as a single commit to the Hugging Face
+dataset at https://huggingface.co/datasets/open-reaction-database/ord-data.
+
+Authentication uses the HF_TOKEN environment variable.
+
+This script is invoked from `.github/workflows/huggingface_mirror.yml`;
+it can also be run locally for manual backfills.
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+from huggingface_hub import CommitOperationAdd, HfApi
+
+HF_REPO_ID = "open-reaction-database/ord-data"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--files-from",
+        type=Path,
+        required=True,
+        help="File containing newline-delimited repo-relative paths to upload.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Local repository root (default: parent of scripts/).",
+    )
+    parser.add_argument(
+        "--commit-message",
+        default="Mirror update from GitHub",
+        help="Commit message for the Hugging Face commit.",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        raise SystemExit("HF_TOKEN environment variable is not set.")
+
+    paths = [
+        line.strip()
+        for line in args.files_from.read_text().splitlines()
+        if line.strip()
+    ]
+    if not paths:
+        print("No files to upload.")
+        return
+
+    operations = []
+    for path in paths:
+        local_path = args.repo_root / path
+        if not local_path.exists():
+            # File was deleted in this commit range; skip (deletions are
+            # not mirrored automatically — handle those manually if needed).
+            print(f"Skipping missing file: {path}")
+            continue
+        operations.append(
+            CommitOperationAdd(path_in_repo=path, path_or_fileobj=str(local_path))
+        )
+
+    if not operations:
+        print("No existing files to upload.")
+        return
+
+    api = HfApi(token=token)
+    api.create_commit(
+        repo_id=HF_REPO_ID,
+        repo_type="dataset",
+        operations=operations,
+        commit_message=args.commit_message,
+    )
+    print(f"Uploaded {len(operations)} file(s) to {HF_REPO_ID}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Mirror the dataset to [open-reaction-database/ord-data on Hugging Face](https://huggingface.co/datasets/open-reaction-database/ord-data) to relieve our shared GitHub LFS quota.

- **README**: recommends the Hugging Face download path; Git LFS framed as a fallback, with a `GIT_LFS_SKIP_SMUDGE=1` clone recipe.
- **`scripts/download_from_huggingface.py`**: wraps `huggingface_hub.snapshot_download`; defaults to `data/**`, with `--allow-pattern`, `--output-dir`, `--revision` overrides.
- **`scripts/upload_to_huggingface.py`**: runs `git diff --name-status` between two SHAs, LFS-pulls only the upload targets, and applies adds + deletes (including renames) as a single `create_commit` on the HF dataset. Supports `--dry-run` and `--summary-file`.
- **`.github/workflows/huggingface_mirror.yml`**:
  - Push to `main` → mirrors changes to HF.
  - PR touching `data/**` or mirror tooling → dry run that posts the planned uploads/deletions to `$GITHUB_STEP_SUMMARY`, no `HF_TOKEN` required.
  - Diff range uses `github.event.before..github.sha` (with empty-tree fallback) so multi-commit pushes are fully covered.
- **`scripts/requirements.txt`**: pins `huggingface_hub>=0.24`.

## Setup required before merge
- Add an `HF_TOKEN` repository secret with write access to `open-reaction-database/ord-data` on Hugging Face.
- The HF dataset already exists at https://huggingface.co/datasets/open-reaction-database/ord-data.

## Test plan
- [ ] Merging this PR triggers the dry-run job on the PR page — verify the "Hugging Face mirror plan" summary shows 0 uploads / 0 deletions (no `data/**` changes here).
- [ ] After adding `HF_TOKEN`, land a small data-only change and confirm a matching commit appears on the HF dataset.
- [ ] Land a deletion and confirm the file is removed on the HF side.
- [ ] Run `python scripts/download_from_huggingface.py --allow-pattern 'data/4d/*.pb.gz'` on a fresh checkout and confirm files land in `data/4d/`.

## Notes
- CI LFS bandwidth is minimized: the job checks out with `GIT_LFS_SKIP_SMUDGE=1` and only LFS-pulls the specific paths being mirrored (~megabytes per push vs. the full ~1 GB corpus).
- The mirror script is fully runnable locally for manual backfills: `python scripts/upload_to_huggingface.py --base=<sha> --head=<sha>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)