### PR TITLE
Convert datasets to parquet (un-shard USPTO) and rework validation CI

### DIFF
--- a/.github/workflows/huggingface_mirror.yml
+++ b/.github/workflows/huggingface_mirror.yml
@@ -16,7 +16,16 @@ on:
       - main
   pull_request:
     paths:
+      # Mirrored content (must stay in sync with MIRROR_PATHSPECS in
+      # scripts/upload_to_huggingface.py).
       - 'data/**'
+      - '.gitattributes'
+      - 'README.md'
+      - 'LICENSE'
+      - 'CITATION.cff'
+      - 'CONTRIBUTING.md'
+      - 'CONTRIBUTORS.md'
+      # Mirror tooling.
       - '.github/workflows/huggingface_mirror.yml'
       - 'scripts/upload_to_huggingface.py'
       - 'scripts/requirements.txt'

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -14,6 +14,12 @@ on:
     # gating on the "Update submission" step.
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+# One in-flight run per PR. New events (pushes, label toggles) cancel
+# the prior run so we are not paying twice for things like LFS checkouts.
+concurrency:
+  group: submission-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   ORD_SCHEMA_TAG: v0.6.3
 

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -10,7 +10,7 @@ name: Submission
 on: [pull_request]
 
 env:
-  ORD_SCHEMA_TAG: v0.6.1
+  ORD_SCHEMA_TAG: v0.6.3
 
 jobs:
   count_reactions:

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -7,7 +7,12 @@
 
 name: Submission
 
-on: [pull_request]
+on:
+  pull_request:
+    # Default trigger types plus labeled/unlabeled so adding or removing the
+    # `skip-update-submission` label re-runs the workflow with the new
+    # gating on the "Update submission" step.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 env:
   ORD_SCHEMA_TAG: v0.6.3
@@ -149,6 +154,11 @@ jobs:
         # Fail gracefully if there is nothing to commit.
         git commit -a -m "Update submission" || (( $? == 1 ))
         git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_HEAD_REF}"
+      # Skipped when the PR carries the `skip-update-submission` label, so
+      # maintainer PRs that touch dataset files but do not need ID/timestamp
+      # assignment (e.g. format conversions) can land without process_dataset
+      # rewriting the inputs.
       if: >-
         env.NUM_CHANGED_FILES != '0' &&
-        ! github.event.pull_request.head.repo.fork
+        ! github.event.pull_request.head.repo.fork &&
+        ! contains(github.event.pull_request.labels.*.name, 'skip-update-submission')

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -29,17 +29,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout ord-data
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         lfs: true
     - name: Checkout ord-schema
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: Open-Reaction-Database/ord-schema
         ref: ${{ env.ORD_SCHEMA_TAG }}
         path: ord-schema
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Install ord_schema
@@ -62,7 +62,7 @@ jobs:
   check_file_types:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Add upstream for comparisons to HEAD
       run: |
         cd "${GITHUB_WORKSPACE}"
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout ord-data
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         lfs: true
@@ -106,7 +106,7 @@ jobs:
         git fetch --no-tags --prune --depth=1 upstream \
           +refs/heads/*:refs/remotes/upstream/*
     - name: Checkout ord-schema
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: Open-Reaction-Database/ord-schema
         ref: ${{ env.ORD_SCHEMA_TAG }}
@@ -125,7 +125,7 @@ jobs:
         echo "NUM_CHANGED_FILES=${LOCAL_NUM_CHANGED}" >> $GITHUB_ENV
         echo "Found ${LOCAL_NUM_CHANGED} changed dataset files"
         cat changed_data_files.txt
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
       if: env.NUM_CHANGED_FILES != '0'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/validation.yml'
 
 env:
-  ORD_SCHEMA_TAG: v0.6.1
+  ORD_SCHEMA_TAG: v0.6.3
 
 jobs:
   validate_pb:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -11,6 +11,13 @@ on:
       # Runs when this file is modified in a PR.
       - '.github/workflows/validation.yml'
 
+# One in-flight matrix per PR (or per push to main). Subsequent events
+# cancel the prior run so we are not paying twice for the LFS-heavy
+# validate_pb / validate_parquet shards.
+concurrency:
+  group: validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   ORD_SCHEMA_TAG: v0.6.3
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,9 +15,10 @@ env:
   ORD_SCHEMA_TAG: v0.6.1
 
 jobs:
-  validate_database:
+  validate_pb:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         filter: [
           'data/[0-4][0-4]',
@@ -59,6 +60,46 @@ jobs:
           --input="data/*/*.pb*" \
           --filter="${FILTER}" \
           --n_jobs=4
+
+  validate_parquet:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Un-sharded USPTO grants parquet — single ~1.7M-reaction file.
+          # Saturates the 4-CPU runner via row-group parallelism in
+          # validate_dataset.py.
+          - name: uspto
+            filter: 'ord_dataset-1158e351757f315b93cbcbe7bc55f38e\.parquet$'
+          # Everything else (negative lookahead on the USPTO parquet id).
+          - name: other
+            filter: '^(?!.*ord_dataset-1158e351757f315b93cbcbe7bc55f38e).*\.parquet$'
+    steps:
+    - name: Checkout ord-data
+      uses: actions/checkout@v2
+      with:
+        lfs: true
+    - name: Checkout ord-schema
+      uses: actions/checkout@v2
+      with:
+        repository: Open-Reaction-Database/ord-schema
+        ref: ${{ env.ORD_SCHEMA_TAG }}
+        path: ord-schema
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install ord_schema
+      run: |
+        cd "${GITHUB_WORKSPACE}/ord-schema"
+        python -m pip install --upgrade pip
+        python -m pip install wheel
+        python -m pip install .
+    - name: Validate parquet datasets
+      env:
+        FILTER: ${{ matrix.filter }}
+      run: |
+        cd "${GITHUB_WORKSPACE}"
         python ./ord-schema/ord_schema/scripts/validate_dataset.py \
           --input="data/*/*.parquet" \
           --filter="${FILTER}" \

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -40,16 +40,16 @@ jobs:
         ]
     steps:
     - name: Checkout ord-data
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         lfs: true
     - name: Checkout ord-schema
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: Open-Reaction-Database/ord-schema
         ref: ${{ env.ORD_SCHEMA_TAG }}
         path: ord-schema
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Install ord_schema
@@ -84,16 +84,16 @@ jobs:
             filter: '^(?!.*ord_dataset-1158e351757f315b93cbcbe7bc55f38e).*\.parquet$'
     steps:
     - name: Checkout ord-data
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         lfs: true
     - name: Checkout ord-schema
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: Open-Reaction-Database/ord-schema
         ref: ${{ env.ORD_SCHEMA_TAG }}
         path: ord-schema
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Install ord_schema

--- a/README.md
+++ b/README.md
@@ -95,3 +95,15 @@ print(f"We have converted the {input_fname} to JSON format shown as below, \n{rx
 ## Contributing
 
 Please see the [Submission Workflow](https://docs.open-reaction-database.org/en/latest/submissions.html) documentation. Make sure to review the [license](https://github.com/open-reaction-database/ord-data/blob/main/LICENSE) and [terms of use](https://github.com/open-reaction-database/ord-data/blob/main/CONTRIBUTING.md#terms-of-use).
+
+## Maintainer notes
+
+### Skipping the `Update submission` step
+
+The submission workflow's `Update submission` step runs `process_dataset.py
+--update --cleanup` to assign reaction/dataset IDs and timestamps to newly
+submitted files and rewrite them to the canonical on-disk format. For
+maintainer PRs that touch dataset files but should *not* be re-processed
+this way — e.g., format conversions or mass migrations of already-finalized
+data — apply the `skip-update-submission` label to the PR. The validation
+side of the workflow still runs.

--- a/data/00/ord_dataset-00005539a1e04c809a9a78647bea649c.parquet
+++ b/data/00/ord_dataset-00005539a1e04c809a9a78647bea649c.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf1686ca6edac300a61acb5a5ee006ab5fd61007962ae19062b3d3c7879f84a9
+size 274285

--- a/data/03/ord_dataset-0316886541d9435489859c2ad7edc863.parquet
+++ b/data/03/ord_dataset-0316886541d9435489859c2ad7edc863.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:786b10eb7815c92e07800b7005fbdd046f15158c834b05596c6b02d3d6d2128e
+size 24703

--- a/data/0c/ord_dataset-0c75d67751634f0594b24b9f498b77c2.parquet
+++ b/data/0c/ord_dataset-0c75d67751634f0594b24b9f498b77c2.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00fe35e881dc9a02feaa9186eaf69a221a44f1a281ea1b01f593953ecd65ede6
+size 29842

--- a/data/10/ord_dataset-10b940e7982c4622b1e1ac879394aba6.parquet
+++ b/data/10/ord_dataset-10b940e7982c4622b1e1ac879394aba6.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79923835d81b529c5d771cd7dc0ad6707348e6ceecbe4528205c47bb6de1d044
+size 43989

--- a/data/11/ord_dataset-1158e351757f315b93cbcbe7bc55f38e.parquet
+++ b/data/11/ord_dataset-1158e351757f315b93cbcbe7bc55f38e.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0fa5e21c621d16714bae1b9157022b5a3ea02db909a2af8d7b5b976f7c950b5
+size 1112719074

--- a/data/17/ord_dataset-172039a759a440219a68af62d203b79b.parquet
+++ b/data/17/ord_dataset-172039a759a440219a68af62d203b79b.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e32594d22839eaae4554642845e4e9dfc6abcf4bcecece6b26f4be64ce3bf39c
+size 21417

--- a/data/1d/ord_dataset-1d3a1a6fb70d46c084602d0688967afc.parquet
+++ b/data/1d/ord_dataset-1d3a1a6fb70d46c084602d0688967afc.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9351ed4883b04c23505e6a1e8a3e216f90b7b79fd1ca72fd18f33c33a94e71b2
+size 11740

--- a/data/20/ord_dataset-2038a3c967db4a32a8fbce288437e929.parquet
+++ b/data/20/ord_dataset-2038a3c967db4a32a8fbce288437e929.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52dd1e2d44ff052592a9f78bd5c9aac454ad90ab7a7f2f9795c4e742f89644d3
+size 17627

--- a/data/2b/ord_dataset-2be11f57f3304e678ea8469baf6dd1bc.parquet
+++ b/data/2b/ord_dataset-2be11f57f3304e678ea8469baf6dd1bc.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7d17ab4af3551a4b2883c6e18c1f3a49b6c19d30d37fad762802aeeb275d948
+size 112943

--- a/data/2b/ord_dataset-2be30f5d8dcd471aa6ad410bdee05902.parquet
+++ b/data/2b/ord_dataset-2be30f5d8dcd471aa6ad410bdee05902.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6846bf47bd0d9652d1164f1dbc65cf730502e117131778499b8a10a98ef828b7
+size 17947

--- a/data/31/ord_dataset-31989f1b2b9d4885b1dd2d9982da4517.parquet
+++ b/data/31/ord_dataset-31989f1b2b9d4885b1dd2d9982da4517.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60f4f1bf9fd81166ce59e3ad8915310b0af5bca13956cab3b331748c1d3194dd
+size 17258

--- a/data/35/ord_dataset-35a5a513f1dd44a3a97c88da99f81a00.parquet
+++ b/data/35/ord_dataset-35a5a513f1dd44a3a97c88da99f81a00.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59f2cdd054631bde7354e21fc7080f0b80ebf2b5379f8ccd78b2df79d86b25d8
+size 19743

--- a/data/3b/ord_dataset-3b5db90e337942ea886b8f5bc5e3aa72.parquet
+++ b/data/3b/ord_dataset-3b5db90e337942ea886b8f5bc5e3aa72.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fce2d70c28db7100b3ca5c3f298484daf4c4043c11a18da066db16ad2e36012c
+size 43118

--- a/data/3b/ord_dataset-3b8a2ef300e145468579027f206a3ac8.parquet
+++ b/data/3b/ord_dataset-3b8a2ef300e145468579027f206a3ac8.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8438f4490541ecd38d92208decc48ff33424d52772cc42701b7eb886fc14b8a
+size 184557

--- a/data/46/ord_dataset-46ff9a32d9e04016b9380b1b1ef949c3.parquet
+++ b/data/46/ord_dataset-46ff9a32d9e04016b9380b1b1ef949c3.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39440ea3e5442dddbb4daccbc48fb53940724085327c0e3b82909e1fd8cc661a
+size 395126

--- a/data/47/ord_dataset-47eaacc46c3a4487bbdf99adb1a15e41.parquet
+++ b/data/47/ord_dataset-47eaacc46c3a4487bbdf99adb1a15e41.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e09c98aa540e15d44959f03028590278bf508650950778568fd264d3a7535c4
+size 8261981

--- a/data/48/ord_dataset-488402f6ec0d441ca2f7d6fabea7c220.parquet
+++ b/data/48/ord_dataset-488402f6ec0d441ca2f7d6fabea7c220.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1b658a9ed389f226baa003488c226fbd00dc35c44fc8e5029ef74b030928788
+size 10249187

--- a/data/4d/ord_dataset-4d431564f3ef4e9c91d8da5836f4eae6.parquet
+++ b/data/4d/ord_dataset-4d431564f3ef4e9c91d8da5836f4eae6.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be51ac3256a9f6793893bd59878f44f223f50ad530a1f71da0c408abf36ef70a
+size 17114

--- a/data/52/ord_dataset-52bd3b0ec72c443aab113bcea09bf3f4.parquet
+++ b/data/52/ord_dataset-52bd3b0ec72c443aab113bcea09bf3f4.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3bf70610705d361b92b40c09ceaffff3d4f66002e958e5ea9c47bba9095297a
+size 10583

--- a/data/54/ord_dataset-5415f83da68e4797856ddd330dda5c61.parquet
+++ b/data/54/ord_dataset-5415f83da68e4797856ddd330dda5c61.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a186a7a7264e94fd958787a5a6a9d810e9c9c00608f1c6e136416098c39a2165
+size 25251

--- a/data/54/ord_dataset-5481550056a14935b76e031fb94b88be.parquet
+++ b/data/54/ord_dataset-5481550056a14935b76e031fb94b88be.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48508c30931b04b4fe2e3bee55b84c83d10f57578c1ed5ccddbfb81875575702
+size 7666127

--- a/data/55/ord_dataset-5540e162c09f4c04905ddc8ba9c931c6.parquet
+++ b/data/55/ord_dataset-5540e162c09f4c04905ddc8ba9c931c6.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e44b014c9041d86e00bc4fb4b70b3c6b3b94c0e35634467ace02c330efcd1a4
+size 13289

--- a/data/55/ord_dataset-55de08a995554f558c25fc43eac62359.parquet
+++ b/data/55/ord_dataset-55de08a995554f558c25fc43eac62359.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e4c3fefafe68d6cb43d5a39b8c441f440ce0c4626abbbe695c922089557b0f7
+size 11719

--- a/data/5c/ord_dataset-5c9a10329a8a48968d18879a48bb8ab2.parquet
+++ b/data/5c/ord_dataset-5c9a10329a8a48968d18879a48bb8ab2.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2ea1363cb895b590ae765e918f98f90d243d6caba763ed74543ae62e503b0b0
+size 712770

--- a/data/5e/ord_dataset-5e8318f0dda04b398c14f4c3adfeb32c.parquet
+++ b/data/5e/ord_dataset-5e8318f0dda04b398c14f4c3adfeb32c.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94de6b8e87229d5db4fe8c17212afa2d3563478ca32aee934cc449559cab0bca
+size 8027

--- a/data/5e/ord_dataset-5eb7f2689f4a42eba63ad9e37e49a5cd.parquet
+++ b/data/5e/ord_dataset-5eb7f2689f4a42eba63ad9e37e49a5cd.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f478e163ab9f9ee2f001172fc9f0c33b0a65ec2dc787c12298f6e85bc86f7a6
+size 11134

--- a/data/67/ord_dataset-675eddcaa6674ce3ae61e79bbc1e1c08.parquet
+++ b/data/67/ord_dataset-675eddcaa6674ce3ae61e79bbc1e1c08.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ecc5469785e55997f244eb5f8d6dbc78029cbb233bd6a140b5f02d5d01860a1
+size 114800

--- a/data/68/ord_dataset-68cb8b4b2b384e3d85b5b1efae58b203.parquet
+++ b/data/68/ord_dataset-68cb8b4b2b384e3d85b5b1efae58b203.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36cea7705307a5e359a176ed3862994e3edc60ae4363fc2f3c5862affff6bb21
+size 419710

--- a/data/6a/ord_dataset-6a0bfcdf53a64c07987822162ae591e2.parquet
+++ b/data/6a/ord_dataset-6a0bfcdf53a64c07987822162ae591e2.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f970251d44ad75b68c8f6b8f3f28ff97f540fb7967d3bbc9b7338a7d7290ed3a
+size 16175

--- a/data/7a/ord_dataset-7acd6ad2bf4d4cff841cad008ab726d5.parquet
+++ b/data/7a/ord_dataset-7acd6ad2bf4d4cff841cad008ab726d5.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6dfe8e151a396c5332668c015bce764d23c667240e443495990205c66e4a1e5
+size 72692

--- a/data/7d/ord_dataset-7d8f5fd922d4497d91cb81489b052746.parquet
+++ b/data/7d/ord_dataset-7d8f5fd922d4497d91cb81489b052746.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d657d1eda5703b58b627565894890269b50b18e987709e70fd7968d83e59101
+size 194483

--- a/data/89/ord_dataset-89b083710e2d441aa0040c361d63359f.parquet
+++ b/data/89/ord_dataset-89b083710e2d441aa0040c361d63359f.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a5cbdae282df3da7249e7525b7ecb739e4892061abe1f66e62c3fd69736ad72
+size 21940

--- a/data/8d/ord_dataset-8d1e28ec1f6b4ee8ad372e0b5ed7a62e.parquet
+++ b/data/8d/ord_dataset-8d1e28ec1f6b4ee8ad372e0b5ed7a62e.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4f7505229e29321b5615f32ec2edcf45c9bc531bee2810d2a8985319b7ee127
+size 20904

--- a/data/99/ord_dataset-99c23cf435dc42f1af884053bc8b11c7.parquet
+++ b/data/99/ord_dataset-99c23cf435dc42f1af884053bc8b11c7.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e01a389cac3e6cce5746ef54dbe6b8d3040d764f987b1fc13790f5aeff5598fa
+size 210626

--- a/data/9b/ord_dataset-9b8aa9a7835143ef8ce3f70abfab7545.parquet
+++ b/data/9b/ord_dataset-9b8aa9a7835143ef8ce3f70abfab7545.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:195765643b4aaad79d9ed82de6737a4855b9f2716e0bc0aa10cff950b7604d39
+size 126909

--- a/data/a1/ord_dataset-a12fa15d036d489c971b0b514caeae52.parquet
+++ b/data/a1/ord_dataset-a12fa15d036d489c971b0b514caeae52.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea52ef52e2ecf3eb33d74ca3ffac14ef539357551d252fbc706e95f60c94fca6
+size 39322

--- a/data/ac/ord_dataset-ac78456835404910b3a4c840248b6ac9.parquet
+++ b/data/ac/ord_dataset-ac78456835404910b3a4c840248b6ac9.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec3befdf2d98c2d122b1e5b8046dfb2bca6b035a1c506c9e1a2ddc4992276d88
+size 126387

--- a/data/b4/ord_dataset-b440f8c90b6343189093770060fc4098.parquet
+++ b/data/b4/ord_dataset-b440f8c90b6343189093770060fc4098.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d289e2e9fbb77df61faadeb65cfadfbee0216b05a7d209b3ae3b3aca04a9993a
+size 111495

--- a/data/bc/ord_dataset-bc349c19b4384756a2aee8aa525b6c2a.parquet
+++ b/data/bc/ord_dataset-bc349c19b4384756a2aee8aa525b6c2a.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4dbdaba59ac728696dea5bc0cafed5c5ab3236cc37da6e29b73e8a792f3b4a3
+size 17150

--- a/data/c5/ord_dataset-c5b00523487a4211a194160edf45e9ab.parquet
+++ b/data/c5/ord_dataset-c5b00523487a4211a194160edf45e9ab.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73c04ce2acaf6cf2b6b3ecda8c623d2a321435f1f5830aedb0a0f1afd562bdc4
+size 179304

--- a/data/cb/ord_dataset-cbcc4048add7468e850b6ec42549c70d.parquet
+++ b/data/cb/ord_dataset-cbcc4048add7468e850b6ec42549c70d.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd62fb8331a5d2d68337882bd711d04f085b6beec7ef1283945f7f72a8cefb81
+size 30311

--- a/data/ce/ord_dataset-ce5045aceb214cfc8bfd0ef3031e2737.parquet
+++ b/data/ce/ord_dataset-ce5045aceb214cfc8bfd0ef3031e2737.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fba1e4a5d3f30708bb925e0d0b93d420c26b17707f45fceb34e579f5f624c772
+size 10361

--- a/data/d2/ord_dataset-d26118acda314269becc35db5c22dc59.parquet
+++ b/data/d2/ord_dataset-d26118acda314269becc35db5c22dc59.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a600968a24eff0a440e30685b2cb7b62030693605574105eb57b7f07329700b
+size 130893

--- a/data/d3/ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c.parquet
+++ b/data/d3/ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8a81d79136a36e14614f2cf4469f13393d675d6393f07d96f19e569623ac887
+size 30174

--- a/data/d9/ord_dataset-d92976309c3a48a3a64a4cf5e7048086.parquet
+++ b/data/d9/ord_dataset-d92976309c3a48a3a64a4cf5e7048086.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78c17145099d29458960ffcb6cec7a8987efeae06b100004be2255ff28e54994
+size 3784674

--- a/data/e7/ord_dataset-e7830cd6b11158b43994ccfb5ee9acb3.parquet
+++ b/data/e7/ord_dataset-e7830cd6b11158b43994ccfb5ee9acb3.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:428d777066426504896fc2a0352838caba173518056ce83b387d9701f67af08e
+size 104636029

--- a/data/ee/ord_dataset-eeba974d3c284aed86d1c1d442260a1e.parquet
+++ b/data/ee/ord_dataset-eeba974d3c284aed86d1c1d442260a1e.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbf6dae9521463c542fa8abccd2a078742c8052c0af11db842d200d94403fac6
+size 36161

--- a/data/fc/ord_dataset-fc83743b978f4deea7d6856deacbfe53.parquet
+++ b/data/fc/ord_dataset-fc83743b978f4deea7d6856deacbfe53.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14095b49acb35adf50d1ff065d7b9d2ccf01d37f57ccaebbb6ce8eddfd11f484
+size 12354

--- a/data/fe/ord_dataset-feaf1b793c6d408aaec1cac7cc3ceadc.parquet
+++ b/data/fe/ord_dataset-feaf1b793c6d408aaec1cac7cc3ceadc.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebefbe9aba687f182d4f068e94be0f7fd71d1189bdb2eff2aca6fedf4d522bf3
+size 37643

--- a/scripts/convert_to_parquet.py
+++ b/scripts/convert_to_parquet.py
@@ -1,0 +1,190 @@
+"""Convert ord-data Dataset protos (.pb.gz) to Parquet, alongside the originals.
+
+Most datasets are converted 1:1 (parquet sibling next to the pb.gz, carrying
+forward name/description/dataset_id). A small set of explicitly-listed
+multi-file groups are merged into single parquet outputs ("un-sharding"):
+
+* All ``uspto-grants-YYYY_MM`` monthly buckets become one ``uspto-grants``
+  parquet. Per-month CML filenames are dropped from the description; per-
+  reaction patent provenance is preserved.
+* The ten ``Training data from .../C8SC04228D (N/10)`` shards become one
+  parquet with the (N/10) marker stripped from the name.
+
+Each merged output gets a deterministic new ``dataset_id`` derived from the
+SHA-256 of the sorted source ids, so re-runs produce the same output filename.
+
+Outputs are placed at ``data/<2-hex-prefix>/ord_dataset-<id>.parquet`` where
+the prefix matches the (existing or new) dataset_id. Existing outputs are
+skipped, so the script is safe to re-run.
+"""
+
+import argparse
+import hashlib
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from ord_schema import message_helpers, parquet_dataset
+from ord_schema.proto import dataset_pb2
+
+logger = logging.getLogger(__name__)
+
+INPUT_GLOB = "data/*/ord_dataset-*.pb.gz"
+
+
+@dataclass(frozen=True)
+class MergeSpec:
+    """A group of pb.gz inputs to be merged into a single parquet output."""
+    label: str  # human-readable for logs
+    name: str  # output Dataset.name
+    description: str  # output Dataset.description
+    matches: callable  # (dataset_pb2.Dataset) -> bool
+
+
+MERGE_SPECS: list[MergeSpec] = [
+    MergeSpec(
+        label="uspto-grants",
+        name="uspto-grants",
+        description=(
+            "Reactions extracted from USPTO granted patents (1976-present), "
+            "originally distributed as monthly buckets and consolidated here "
+            "into a single dataset. Per-reaction patent provenance is "
+            "available via Reaction.provenance.patent."
+        ),
+        matches=lambda ds: ds.name.startswith("uspto-grants-"),
+    ),
+    MergeSpec(
+        label="C8SC04228D-training",
+        name="Training data from https://doi.org/10.1039/C8SC04228D",
+        description=(
+            "409035 reaction SMILES downloaded from "
+            "https://github.com/connorcoley/rexgen_direct"
+        ),
+        matches=lambda ds: ds.name.startswith(
+            "Training data from https://doi.org/10.1039/C8SC04228D"
+        ),
+    ),
+]
+
+
+def _output_path(repo_root: Path, dataset_id: str) -> Path:
+    prefix = dataset_id[len("ord_dataset-"):][:2]
+    return repo_root / "data" / prefix / f"{dataset_id}.parquet"
+
+
+def _derive_id(source_ids: list[str]) -> str:
+    """Deterministic dataset_id for a merged output, derived from inputs."""
+    digest = hashlib.sha256(",".join(sorted(source_ids)).encode()).hexdigest()[:32]
+    return f"ord_dataset-{digest}"
+
+
+def _load_metadata(path: Path) -> dataset_pb2.Dataset:
+    """Load a Dataset just for its scalar metadata (name/description/id).
+
+    Reactions are still parsed (the proto is monolithic), but the caller
+    ignores them. Cheap enough at our scale (~50 ms each).
+    """
+    return message_helpers.load_message(str(path), dataset_pb2.Dataset)
+
+
+def _classify(inputs: list[Path]) -> tuple[dict[str, list[Path]], list[Path]]:
+    """Split inputs into (merge groups, singletons) by name."""
+    groups: dict[str, list[Path]] = {spec.label: [] for spec in MERGE_SPECS}
+    singletons: list[Path] = []
+    for path in inputs:
+        meta = _load_metadata(path)
+        for spec in MERGE_SPECS:
+            if spec.matches(meta):
+                groups[spec.label].append(path)
+                break
+        else:
+            singletons.append(path)
+    return groups, singletons
+
+
+def _convert_singleton(src: Path, repo_root: Path, dry_run: bool) -> str:
+    dataset = message_helpers.load_message(str(src), dataset_pb2.Dataset)
+    if not dataset.dataset_id:
+        raise ValueError(f"{src}: missing dataset_id")
+    out = _output_path(repo_root, dataset.dataset_id)
+    if out.exists():
+        return f"skip (exists)  {out.relative_to(repo_root)}"
+    if dry_run:
+        return f"would write    {out.relative_to(repo_root)}  ({len(dataset.reactions)} rxns)"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    parquet_dataset.write_dataset(dataset, str(out))
+    return f"wrote          {out.relative_to(repo_root)}  ({len(dataset.reactions)} rxns)"
+
+
+def _convert_group(spec: MergeSpec, sources: list[Path], repo_root: Path, dry_run: bool) -> str:
+    source_ids = []
+    for src in sources:
+        meta = _load_metadata(src)
+        if not meta.dataset_id:
+            raise ValueError(f"{src}: missing dataset_id")
+        source_ids.append(meta.dataset_id)
+    new_id = _derive_id(source_ids)
+    out = _output_path(repo_root, new_id)
+    if out.exists():
+        return f"skip (exists)  {out.relative_to(repo_root)}  [{spec.label}, {len(sources)} sources]"
+    if dry_run:
+        return f"would merge    {out.relative_to(repo_root)}  [{spec.label}, {len(sources)} sources]"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    total = 0
+    with parquet_dataset.DatasetWriter(
+        str(out),
+        name=spec.name,
+        description=spec.description,
+        dataset_id=new_id,
+    ) as writer:
+        for src in sorted(sources):  # deterministic write order
+            ds = message_helpers.load_message(str(src), dataset_pb2.Dataset)
+            writer.write_all(ds.reactions)
+            total += len(ds.reactions)
+            del ds  # release memory before loading the next input
+    return f"wrote          {out.relative_to(repo_root)}  [{spec.label}, {len(sources)} sources, {total} rxns]"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Repository root containing data/ (default: parent of this script's dir).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan only; do not write any parquet files.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    inputs = sorted(args.repo_root.glob(INPUT_GLOB))
+    if not inputs:
+        sys.exit(f"No inputs matched {args.repo_root / INPUT_GLOB}")
+    logger.info("Found %d pb.gz inputs", len(inputs))
+
+    groups, singletons = _classify(inputs)
+    logger.info(
+        "Classified: %d singletons, %s",
+        len(singletons),
+        ", ".join(f"{len(v)}x {k}" for k, v in groups.items()),
+    )
+
+    for spec in MERGE_SPECS:
+        sources = groups[spec.label]
+        if not sources:
+            logger.warning("No inputs matched merge spec %r", spec.label)
+            continue
+        logger.info(_convert_group(spec, sources, args.repo_root, args.dry_run))
+
+    for src in singletons:
+        logger.info(_convert_singleton(src, args.repo_root, args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload_to_huggingface.py
+++ b/scripts/upload_to_huggingface.py
@@ -22,7 +22,18 @@ from pathlib import Path
 from huggingface_hub import CommitOperationAdd, CommitOperationDelete, HfApi
 
 HF_REPO_ID = "open-reaction-database/ord-data"
-DATA_PATHSPEC = "data/**"
+# Files mirrored to the HF dataset. Datasets + dataset-card-relevant docs +
+# .gitattributes (so LFS rules stay in sync). GitHub-side infrastructure
+# (.github/, scripts/, badges/) is intentionally excluded.
+MIRROR_PATHSPECS = (
+    "data/**",
+    ".gitattributes",
+    "README.md",
+    "LICENSE",
+    "CITATION.cff",
+    "CONTRIBUTING.md",
+    "CONTRIBUTORS.md",
+)
 
 
 @dataclass
@@ -62,7 +73,7 @@ def compute_plan(base: str, head: str, repo_root: Path) -> DiffPlan:
     diff = subprocess.run(
         [
             "git", "diff", "--name-status", "--find-renames",
-            "--diff-filter=ACMRD", base, head, "--", DATA_PATHSPEC,
+            "--diff-filter=ACMRD", base, head, "--", *MIRROR_PATHSPECS,
         ],
         cwd=repo_root, check=True, capture_output=True, text=True,
     )


### PR DESCRIPTION
## Summary

Adds parquet copies of every dataset alongside the existing pb.gz files,
consolidates two shard groups into single un-sharded parquet files, and
restructures CI to validate the new format efficiently.

### Conversion (commit `ca97f95`)
- 489 monthly `uspto-grants-YYYY_MM` pb.gz files → **one** un-sharded `uspto-grants` parquet (1.77M reactions, ~1.0 GB). Per-month CML filename provenance dropped from the description; per-reaction patent provenance is preserved.
- 10 `(N/10)` Training-data shards from doi.org/10.1039/C8SC04228D → **one** parquet (409 035 reactions).
- 47 other datasets converted 1:1, keeping name/description/dataset_id.
- pb.gz inputs kept in place.
- Merged-output `dataset_id`s derived deterministically from the sorted source ids, so re-runs are idempotent.
- New `scripts/convert_to_parquet.py` is the script that did this; left in-tree as the audit trail and for future re-conversions.

### CI restructure (commit `ca97f95`)
- Renames `validate_database` → `validate_pb` (the input glob has always matched all `*.pb*` extensions). Adds `fail-fast: false` so one shard failure does not cancel the others. The old 9-way hex-prefix matrix is otherwise unchanged.
- Removes the parquet pass that briefly lived inside that job (added in #240).
- Adds a new `validate_parquet` job with a 2-element matrix:
  - `uspto`: filters to the un-sharded USPTO parquet only. Row-group parallelism in `validate_dataset.py` saturates the 4-CPU runner on this single ~1.77M-reaction file.
  - `other`: negative lookahead on the USPTO id; the remaining 48 parquet files validate in parallel at file + row-group level.
- Local validation of all 49 parquet files (n_jobs=8 on an 8-CPU machine) completed in 19m58s with zero errors.

### Tag bump (commit `e0523b6`)
- `ORD_SCHEMA_TAG` v0.6.1 → **v0.6.3**. Required by the new `validate_parquet` job: row-group parallelism in `validate_dataset.py` landed in v0.6.2 (Open-Reaction-Database/ord-schema#812). v0.6.3 is the latest release.

### HF mirror scope (commit `ff91745`)
- `scripts/upload_to_huggingface.py` and `huggingface_mirror.yml` widened to mirror `data/`, `.gitattributes`, `README.md`, `LICENSE`, `CITATION.cff`, `CONTRIBUTING.md`, `CONTRIBUTORS.md` — matches what already exists on the HF dataset. GitHub-side infrastructure (`.github/`, `scripts/`, `badges/`) stays excluded.
- One-time bootstrap already done: `.gitattributes` was pushed to the HF dataset out-of-band so future parquet uploads preupload as LFS regardless of size. (Without this, small singleton parquets would have landed as regular blobs.)

## Test plan
- [ ] `validate_pb` (9 shards) all pass.
- [ ] `validate_parquet (uspto)` passes.
- [ ] `validate_parquet (other)` passes.
- [ ] `process_submission` validates the 49 added parquet files cleanly.
- [ ] `huggingface_mirror` dry-run shows 49 parquet uploads, 0 deletions.

## Notes for reviewers
- This PR will trigger 11 LFS-heavy CI checkouts (9 pb shards + 2 parquet shards) plus `process_submission` and the HF mirror dry-run.
- `validate_pb` is renamed → required-checks in branch protection (if any) will need updating after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)