### PR TITLE
Backfill parquet versions for 4 datasets added after #241

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ Python ≥3.11. Because it reads every `.pb.gz` to classify by name, pull the
 inputs first:
 
 ```bash
-uv venv --python 3.11 && source .venv/bin/activate   # or: python -m venv .venv
-pip install "ord-schema==0.6.3"                       # match ORD_SCHEMA_TAG
+uv venv --python 3.11 && source .venv/bin/activate  # or: python -m venv .venv
+pip install "ord-schema==0.6.3"  # match ORD_SCHEMA_TAG
 
-git lfs pull --include="data/**/*.pb.gz"    # the converter reads pb.gz content
-python scripts/convert_to_parquet.py --dry-run    # preview what it will write
-python scripts/convert_to_parquet.py              # write the Parquet siblings
+git lfs pull --include="data/**/*.pb.gz"  # the converter reads pb.gz content
+python scripts/convert_to_parquet.py --dry-run  # preview what it will write
+python scripts/convert_to_parquet.py  # write the Parquet siblings
 ```
 
 Commit the new `.parquet` files (they become LFS objects), push them (see
@@ -207,7 +207,7 @@ auth is the GitHub CLI:
 
 ```bash
 git config lfs.pushurl https://github.com/open-reaction-database/ord-data.git/info/lfs
-gh auth setup-git        # let git use your gh token for github.com over HTTPS
+gh auth setup-git  # let git use your gh token for github.com over HTTPS
 git push -u origin <branch>
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,3 +166,58 @@ maintainer PRs that touch dataset files but should *not* be re-processed
 this way — e.g., format conversions or mass migrations of already-finalized
 data — apply the `skip-update-submission` label to the PR. The validation
 side of the workflow still runs.
+
+### Converting datasets to Parquet
+
+Datasets are stored as `.pb.gz`; most also have a Parquet sibling. New
+submissions arrive as `.pb.gz` only, so their Parquet versions are backfilled
+with [`scripts/convert_to_parquet.py`](scripts/convert_to_parquet.py). The
+script globs every `data/**/*.pb.gz`, merges the known de-shard groups (the
+`uspto-grants-YYYY_MM` monthly buckets and the `C8SC04228D` shards) into single
+outputs, converts everything else 1:1 (carrying the existing `dataset_id`), and
+skips any output that already exists — so it is safe to re-run and writes only
+what is missing.
+
+It needs `ord_schema` at the pinned `ORD_SCHEMA_TAG` (see the workflows) and
+Python ≥3.11. Because it reads every `.pb.gz` to classify by name, pull the
+inputs first:
+
+```bash
+uv venv --python 3.11 && source .venv/bin/activate   # or: python -m venv .venv
+pip install "ord-schema==0.6.3"                       # match ORD_SCHEMA_TAG
+
+git lfs pull --include="data/**/*.pb.gz"    # the converter reads pb.gz content
+python scripts/convert_to_parquet.py --dry-run    # preview what it will write
+python scripts/convert_to_parquet.py              # write the Parquet siblings
+```
+
+Commit the new `.parquet` files (they become LFS objects), push them (see
+[Pushing new LFS objects](#pushing-new-lfs-objects)), and open the PR with the
+`skip-update-submission` label. Validation runs against the full dataset on
+merge to `main`.
+
+### Pushing new LFS objects
+
+[`.lfsconfig`](.lfsconfig) routes LFS **reads** to the Hugging Face mirror and
+deliberately sets no `pushurl`, so a plain push would try to upload new objects
+to HF — which you cannot write. Point LFS uploads at GitHub for the push, and
+make sure git can authenticate to `github.com` over **HTTPS** for the LFS API
+(the LFS endpoint is HTTPS even when your `git` remote is SSH). The simplest
+auth is the GitHub CLI:
+
+```bash
+git config lfs.pushurl https://github.com/open-reaction-database/ord-data.git/info/lfs
+gh auth setup-git        # let git use your gh token for github.com over HTTPS
+git push -u origin <branch>
+```
+
+Or, as a one-off without persisting any config:
+
+```bash
+git -c lfs.pushurl=https://github.com/open-reaction-database/ord-data.git/info/lfs \
+    -c 'credential.https://github.com.helper=!gh auth git-credential' \
+    push -u origin <branch>
+```
+
+Reads stay on the mirror; only your uploads go to GitHub. On merge to `main`,
+`huggingface_mirror.yml` copies the new objects to Hugging Face.

--- a/data/1e/ord_dataset-1ec2807f02fa4beda27d2a81b86eb843.parquet
+++ b/data/1e/ord_dataset-1ec2807f02fa4beda27d2a81b86eb843.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1fd81bb3034644117b7d07e0471ede7370597bb4bd2433dd4b5c20bf02fad99
+size 99755

--- a/data/80/ord_dataset-805ad863feef48579d95d86a728035f4.parquet
+++ b/data/80/ord_dataset-805ad863feef48579d95d86a728035f4.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31b7c4762145e5dad973050373cd967bdd85caf3a9858767c83a17fed6c4af36
+size 5088296

--- a/data/c7/ord_dataset-c703268ea43a4c7e802c6048b6166b34.parquet
+++ b/data/c7/ord_dataset-c703268ea43a4c7e802c6048b6166b34.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:159472bff84a548cb2def33ae92ff36c27139271372e38e70bba8eea152760d3
+size 16939

--- a/data/dc/ord_dataset-dc0249930af34d17a3c76881a762aebf.parquet
+++ b/data/dc/ord_dataset-dc0249930af34d17a3c76881a762aebf.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baaa0748a4a561705df275c3152a67ef52605a33249f674129f24c1abecfb2b9
+size 20160


### PR DESCRIPTION
## What

Backfills parquet versions for the four datasets submitted *after* the parquet conversion (#241), which therefore only had `.pb.gz`:

- `data/1e/ord_dataset-1ec2807f…` — catechol transient flow (#235), 1227 reactions
- `data/c7/ord_dataset-c703268e…` — decarboxylative olefination, Bayesian optimization (#238), 120 reactions
- `data/dc/ord_dataset-dc024993…` — decarboxylative olefination, transfer learning (#238), 136 reactions
- `data/80/ord_dataset-805ad863…` — Cernak 50k Pd/Ni/Cu C–N coupling (#243), 50688 reactions

## How

Generated 1:1 parquet siblings with `scripts/convert_to_parquet.py` (the singleton path — none of the four match a de-shard `MERGE_SPEC`, so no merging applies and each keeps its existing `dataset_id`). Reaction counts match the originals exactly (1227 / 120 / 136 / 50688), and the parquet outputs round-trip with matching row counts. `main` is merged in so the branch carries the #243 `.pb.gz` alongside its new parquet sibling.

The `skip-update-submission` label is set because these are format conversions of already-finalized datasets that should not be re-processed by `process_dataset --update`. Validation runs against the full dataset on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR backfills Parquet siblings for datasets that were merged to `main` after the initial Parquet-conversion PR (#241) and therefore only had `.pb.gz` files. It also adds a maintainer-facing README section documenting the conversion and LFS-push workflow.

- Four new LFS-tracked `.parquet` files are added: the catechol transient flow dataset (1227 reactions), two decarboxylative olefination datasets (120 and 136 reactions), and the Cernak C–N coupling dataset — all 1:1 singletons carrying their existing `dataset_id`s.
- The README additions are accurate: the `--dry-run` flag exists in `scripts/convert_to_parquet.py`, and `ord-schema==0.6.3` matches `ORD_SCHEMA_TAG: v0.6.3` used in the CI workflow files.
- The PR title and description say \"3 datasets\" but the diff includes a fourth parquet file (`data/80/ord_dataset-805ad863…`) for the Cernak dataset; the description should be updated before merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds LFS-tracked Parquet siblings for four already-finalised datasets and accurate maintainer documentation; no logic changes.

All changes are additive: four new Parquet LFS pointers and README documentation. The conversion script is idempotent and was run with validate_dataset.py passing locally. The README instructions accurately reflect the script flags and pinned schema version used in CI.

No files require special attention; the discrepancy between the PR description ('3 datasets') and the four added files is cosmetic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds two new maintainer sections: 'Converting datasets to Parquet' and 'Pushing new LFS objects'. Both are accurate — `--dry-run` flag exists in the script, `ord-schema==0.6.3` matches `ORD_SCHEMA_TAG: v0.6.3` in the workflow files. |
| data/1e/ord_dataset-1ec2807f02fa4beda27d2a81b86eb843.parquet | New LFS pointer for the catechol transient flow dataset (1227 reactions) — parquet sibling for the existing `.pb.gz`. |
| data/c7/ord_dataset-c703268ea43a4c7e802c6048b6166b34.parquet | New LFS pointer for the Bayesian optimization decarboxylative olefination dataset (120 reactions) — parquet sibling for the existing `.pb.gz`. |
| data/dc/ord_dataset-dc0249930af34d17a3c76881a762aebf.parquet | New LFS pointer for the transfer learning decarboxylative olefination dataset (136 reactions) — parquet sibling for the existing `.pb.gz`. |
| data/80/ord_dataset-805ad863feef48579d95d86a728035f4.parquet | New LFS pointer for the Cernak C–N coupling dataset — parquet sibling added in the HEAD commit, but not mentioned in the PR title or description. |

</details>

</details>

<sub>Reviews (4): Last reviewed commit: ["Backfill parquet version for Cernak C–N ..."](https://github.com/open-reaction-database/ord-data/commit/e3f73cacaaf66b7e5e24395de910c7c427f6fe04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37136876)</sub>

<!-- /greptile_comment -->