### PR TITLE
Allow targeted singleton conversions in convert_to_parquet.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,29 @@ skips any output that already exists — so it is safe to re-run and writes only
 what is missing.
 
 It needs `ord_schema` at the pinned `ORD_SCHEMA_TAG` (see the workflows) and
-Python ≥3.11. Because it reads every `.pb.gz` to classify by name, pull the
-inputs first:
+Python ≥3.11:
 
 ```bash
 uv venv --python 3.11 && source .venv/bin/activate  # or: python -m venv .venv
 pip install "ord-schema==0.6.3"  # match ORD_SCHEMA_TAG
+```
 
+For the usual case — backfilling a handful of newly-submitted datasets — pass
+their `.pb.gz` paths explicitly. Only those are converted 1:1, so you pull just
+the named objects (a de-shard group member is refused, since it must be merged,
+not converted alone):
+
+```bash
+git lfs pull --include="data/dc/ord_dataset-<id>.pb.gz"  # only what you convert
+python scripts/convert_to_parquet.py --dry-run data/dc/ord_dataset-<id>.pb.gz
+python scripts/convert_to_parquet.py data/dc/ord_dataset-<id>.pb.gz
+```
+
+To (re-)convert the whole corpus instead, run it with no arguments: it globs
+every `data/**/*.pb.gz` and merges the de-shard groups, which means reading
+every input, so pull them all first:
+
+```bash
 git lfs pull --include="data/**/*.pb.gz"  # the converter reads pb.gz content
 python scripts/convert_to_parquet.py --dry-run  # preview what it will write
 python scripts/convert_to_parquet.py  # write the Parquet siblings

--- a/scripts/convert_to_parquet.py
+++ b/scripts/convert_to_parquet.py
@@ -115,8 +115,15 @@ def _classify(inputs: list[Path]) -> tuple[dict[str, list[Path]], list[Path]]:
     return groups, singletons
 
 
-def _convert_singleton(src: Path, repo_root: Path, dry_run: bool) -> str:
-    dataset = message_helpers.load_message(str(src), dataset_pb2.Dataset)
+def _convert_singleton(
+    src: Path,
+    repo_root: Path,
+    dry_run: bool,
+    *,
+    dataset: dataset_pb2.Dataset | None = None,
+) -> str:
+    if dataset is None:
+        dataset = message_helpers.load_message(str(src), dataset_pb2.Dataset)
     if not dataset.dataset_id:
         raise ValueError(f"{src}: missing dataset_id")
     out = _output_path(repo_root, dataset.dataset_id)
@@ -165,17 +172,27 @@ def _convert_explicit(paths: list[Path], repo_root: Path, dry_run: bool) -> None
     a de-shard group is refused, since converting it alone would write a wrong
     standalone parquet instead of being merged. This lets a backfill pull only
     the named objects rather than every ``data/**/*.pb.gz``.
+
+    Validation is a separate first pass so an invalid path aborts the whole
+    batch before any parquet is written (all-or-nothing). Each input is parsed
+    once and the loaded Dataset is reused for conversion.
     """
+    loaded: list[tuple[Path, dataset_pb2.Dataset]] = []
     for path in paths:
         if not path.is_file():
             sys.exit(f"{path}: not a file")
-        spec = _merge_spec_for(_load_metadata(path))
+        dataset = message_helpers.load_message(str(path), dataset_pb2.Dataset)
+        spec = _merge_spec_for(dataset)
         if spec is not None:
             sys.exit(
                 f"{path}: belongs to de-shard group {spec.label!r}; run a full "
                 "conversion (no explicit inputs) so it is merged correctly."
             )
-        logger.info(_convert_singleton(path, repo_root, dry_run))
+        if not dataset.dataset_id:
+            sys.exit(f"{path}: missing dataset_id")
+        loaded.append((path, dataset))
+    for path, dataset in loaded:
+        logger.info(_convert_singleton(path, repo_root, dry_run, dataset=dataset))
 
 
 def main() -> None:

--- a/scripts/convert_to_parquet.py
+++ b/scripts/convert_to_parquet.py
@@ -16,6 +16,12 @@ SHA-256 of the sorted source ids, so re-runs produce the same output filename.
 Outputs are placed at ``data/<2-hex-prefix>/ord_dataset-<id>.parquet`` where
 the prefix matches the (existing or new) dataset_id. Existing outputs are
 skipped, so the script is safe to re-run.
+
+By default the script globs every ``data/**/*.pb.gz`` (so de-shard groups can be
+merged), which requires all inputs to be present. To backfill a few new
+singleton datasets without pulling the whole corpus, pass their pb.gz paths as
+positional arguments: only those are converted (1:1), and any path belonging to
+a de-shard group is refused.
 """
 
 import argparse
@@ -88,16 +94,22 @@ def _load_metadata(path: Path) -> dataset_pb2.Dataset:
     return message_helpers.load_message(str(path), dataset_pb2.Dataset)
 
 
+def _merge_spec_for(meta: dataset_pb2.Dataset) -> "MergeSpec | None":
+    """Return the MergeSpec a dataset belongs to, or None if it is a singleton."""
+    for spec in MERGE_SPECS:
+        if spec.matches(meta):
+            return spec
+    return None
+
+
 def _classify(inputs: list[Path]) -> tuple[dict[str, list[Path]], list[Path]]:
     """Split inputs into (merge groups, singletons) by name."""
     groups: dict[str, list[Path]] = {spec.label: [] for spec in MERGE_SPECS}
     singletons: list[Path] = []
     for path in inputs:
-        meta = _load_metadata(path)
-        for spec in MERGE_SPECS:
-            if spec.matches(meta):
-                groups[spec.label].append(path)
-                break
+        spec = _merge_spec_for(_load_metadata(path))
+        if spec is not None:
+            groups[spec.label].append(path)
         else:
             singletons.append(path)
     return groups, singletons
@@ -146,8 +158,39 @@ def _convert_group(spec: MergeSpec, sources: list[Path], repo_root: Path, dry_ru
     return f"wrote          {out.relative_to(repo_root)}  [{spec.label}, {len(sources)} sources, {total} rxns]"
 
 
+def _convert_explicit(paths: list[Path], repo_root: Path, dry_run: bool) -> None:
+    """Convert specific pb.gz files as singletons, skipping the global glob.
+
+    Each input must be a singleton (its name matches no MERGE_SPEC); a member of
+    a de-shard group is refused, since converting it alone would write a wrong
+    standalone parquet instead of being merged. This lets a backfill pull only
+    the named objects rather than every ``data/**/*.pb.gz``.
+    """
+    for path in paths:
+        if not path.is_file():
+            sys.exit(f"{path}: not a file")
+        spec = _merge_spec_for(_load_metadata(path))
+        if spec is not None:
+            sys.exit(
+                f"{path}: belongs to de-shard group {spec.label!r}; run a full "
+                "conversion (no explicit inputs) so it is merged correctly."
+            )
+        logger.info(_convert_singleton(path, repo_root, dry_run))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "inputs",
+        nargs="*",
+        type=Path,
+        help=(
+            "Specific .pb.gz files to convert as singletons. When given, only "
+            "these are processed (no global glob, no de-shard merging), so you "
+            "need only pull the named objects. Each must not belong to a "
+            "de-shard group. Default: glob every data/**/*.pb.gz."
+        ),
+    )
     parser.add_argument(
         "--repo-root",
         type=Path,
@@ -162,6 +205,10 @@ def main() -> None:
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if args.inputs:
+        _convert_explicit(args.inputs, args.repo_root, args.dry_run)
+        return
 
     inputs = sorted(args.repo_root.glob(INPUT_GLOB))
     if not inputs:


### PR DESCRIPTION
## What

`scripts/convert_to_parquet.py` now accepts explicit `.pb.gz` paths as positional arguments. When given, it converts only those files 1:1 — no global glob, no de-shard merging — so backfilling a newly-submitted dataset pulls just the named LFS objects instead of the entire `data/**/*.pb.gz` corpus.

## Why

The default run globs every `data/**/*.pb.gz` and loads each one to classify it against the de-shard `MERGE_SPECS`. That requires all inputs present, so backfilling a single post-conversion dataset (e.g. the work in #245) meant pulling hundreds of LFS objects — directly at odds with this repo's bandwidth-minimization goals. Targeted mode reads only what it converts.

## How

- New positional `inputs` arg. With inputs, `main` dispatches to `_convert_explicit`, which converts each as a singleton and **refuses** any path whose name matches a de-shard group (converting a shard alone would write a wrong standalone parquet instead of being merged — run a full conversion for those).
- Extracted the name→`MergeSpec` lookup into `_merge_spec_for`, shared by glob-mode `_classify` and the explicit path.
- No behaviour change for the default (no-arg) run.

Verified locally against the Cernak C–N coupling dataset (`805ad863…`, 50688 rxns): `--dry-run <path>` reports the expected singleton write, and a synthetic `uspto-grants-*` input is correctly refused with exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a targeted conversion mode to `scripts/convert_to_parquet.py` so callers can convert specific `.pb.gz` files without pulling the entire LFS corpus. The default (no-arg) glob-and-merge behaviour is unchanged.

- New `inputs` positional arg triggers `_convert_explicit`, which does a two-pass validation (file exists, not a de-shard group member, has `dataset_id`) before writing any output — making the batch all-or-nothing.
- `_merge_spec_for` is extracted from `_classify` and reused, and `_convert_singleton` gains an optional `dataset=` kwarg so the loaded proto is not parsed twice in explicit mode.
- README is updated with step-by-step LFS pull and conversion commands for both modes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — new code path is additive, default behaviour is unchanged, and all previously flagged concerns (partial writes on abort, double file I/O) have been resolved in this revision.

The explicit-path mode is well-scoped: validation runs in a separate first pass so no parquet is written if any input is invalid, the pre-loaded Dataset is threaded through to avoid redundant parsing, and de-shard members are correctly refused. The glob/merge path is untouched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/convert_to_parquet.py | Adds targeted singleton conversion via new `_convert_explicit` and `_merge_spec_for` helpers, and extends `_convert_singleton` with an optional pre-loaded dataset; logic is correct, two-pass validation is all-or-nothing, no issues found. |
| README.md | Documents the new explicit-path mode with LFS pull examples; accurate and well-structured. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Document targeted single-dataset convers..."](https://github.com/open-reaction-database/ord-data/commit/ac7fe226b115f1500954b0fafa80ef63cd6de5a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38758909)</sub>

<!-- /greptile_comment -->