### PR TITLE
Compose a Hugging Face dataset card with generated configs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,3 +10,32 @@ identifiers:
 url: 'https://open-reaction-database.org'
 repository: 'https://github.com/open-reaction-database/ord-data'
 license: CC-BY-SA-4.0
+preferred-citation:
+  type: article
+  title: The Open Reaction Database
+  authors:
+    - family-names: Kearnes
+      given-names: Steven M.
+    - family-names: Maser
+      given-names: Michael R.
+    - family-names: Wleklinski
+      given-names: Michael
+    - family-names: Kast
+      given-names: Anton
+    - family-names: Doyle
+      given-names: Abigail G.
+    - family-names: Dreher
+      given-names: Spencer D.
+    - family-names: Hawkins
+      given-names: Joel M.
+    - family-names: Jensen
+      given-names: Klavs F.
+    - family-names: Coley
+      given-names: Connor W.
+  journal: Journal of the American Chemical Society
+  year: 2021
+  volume: 143
+  issue: 45
+  start: 18820
+  end: 18826
+  doi: 10.1021/jacs.1c09820

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,2 @@
 huggingface_hub>=0.24
+pyyaml>=6.0

--- a/scripts/upload_to_huggingface.py
+++ b/scripts/upload_to_huggingface.py
@@ -314,7 +314,11 @@ def main() -> None:
         print("Nothing to mirror.")
         return
     if args.dry_run:
-        print("Dry run: not fetching LFS or contacting Hugging Face.")
+        if composed_readme is not None:
+            _, front_matter, _ = composed_readme.split("---\n", 2)
+            print("\nComposed dataset card front matter (license, tags, configs):")
+            print(front_matter.rstrip())
+        print("\nDry run: not fetching LFS or contacting Hugging Face.")
         return
 
     token = os.environ.get("HF_TOKEN")

--- a/scripts/upload_to_huggingface.py
+++ b/scripts/upload_to_huggingface.py
@@ -5,6 +5,13 @@ uploads and deletions, fetches only the needed LFS objects, and applies
 the changes as a single commit on the Hugging Face dataset at
 https://huggingface.co/datasets/open-reaction-database/ord-data.
 
+The mirror's README is a composed dataset card — YAML front matter (license,
+tags, citation, and one config per dataset) followed by the GitHub README
+body — so the Hugging Face page has a working dataset viewer and searchable
+metadata. The GitHub README itself stays plain (front matter would render as
+a table there). The card is regenerated on every mirror commit, so its config
+list always matches the parquet files on disk.
+
 Authentication uses the HF_TOKEN environment variable (not required in
 `--dry-run` mode).
 
@@ -19,6 +26,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
 from huggingface_hub import CommitOperationAdd, CommitOperationDelete, HfApi
 
 HF_REPO_ID = "open-reaction-database/ord-data"
@@ -34,6 +42,23 @@ MIRROR_PATHSPECS = (
     "CONTRIBUTING.md",
     "CONTRIBUTORS.md",
 )
+
+# Dataset-card front matter written only to the Hugging Face mirror.
+CARD_LICENSE = "cc-by-sa-4.0"
+CARD_TAGS = ("chemistry", "reactions", "cheminformatics")
+CARD_PRETTY_NAME = "The Open Reaction Database"
+
+# Datasets that get a named config in addition to their `ord_dataset-<id>` one.
+# `uspto-grants` is the full patent extraction; `uspto-mit` is the reaction
+# prediction benchmark (10.1039/C8SC04228D) with real train/validation/test
+# splits. The default config is every dataset except these. Keyed by
+# dataset_id (the parquet filename stem), which is stable across renames.
+USPTO_GRANTS_ID = "ord_dataset-1158e351757f315b93cbcbe7bc55f38e"
+USPTO_MIT_SPLITS = {
+    "train": "ord_dataset-e7830cd6b11158b43994ccfb5ee9acb3",
+    "validation": "ord_dataset-5481550056a14935b76e031fb94b88be",
+    "test": "ord_dataset-488402f6ec0d441ca2f7d6fabea7c220",
+}
 
 
 @dataclass
@@ -80,19 +105,38 @@ def compute_plan(base: str, head: str, repo_root: Path) -> DiffPlan:
     return parse_name_status(diff.stdout)
 
 
-def write_summary(plan: DiffPlan, path: Path | None) -> None:
+def write_summary(
+    plan: DiffPlan, composed_readme: str | None, path: Path | None
+) -> None:
     if path is None:
         return
+    uploads_line = f"- Uploads: **{len(plan.uploads)}**"
+    if composed_readme is not None:
+        uploads_line += " + composed `README.md`"
     lines = [
         f"## Hugging Face mirror plan ({HF_REPO_ID})",
         "",
-        f"- Uploads: **{len(plan.uploads)}**",
+        uploads_line,
         f"- Deletions: **{len(plan.deletions)}**",
     ]
     if plan.uploads:
         lines += ["", "### Uploads", "", "```", *plan.uploads, "```"]
     if plan.deletions:
         lines += ["", "### Deletions", "", "```", *plan.deletions, "```"]
+    if composed_readme is not None:
+        # Fence with four backticks so the README's own ``` blocks survive.
+        lines += [
+            "",
+            "### Composed dataset card (`README.md` on Hugging Face)",
+            "",
+            "<details><summary>Show composed README.md</summary>",
+            "",
+            "````markdown",
+            composed_readme.rstrip(),
+            "````",
+            "",
+            "</details>",
+        ]
     # Append rather than overwrite so it plays well with $GITHUB_STEP_SUMMARY.
     with path.open("a") as fh:
         fh.write("\n".join(lines) + "\n")
@@ -104,6 +148,124 @@ def lfs_pull(paths: list[str], repo_root: Path) -> None:
     subprocess.run(
         ["git", "lfs", "pull", "--include", ",".join(paths)],
         cwd=repo_root, check=True,
+    )
+
+
+def _dataset_id(parquet_path: str) -> str:
+    """Return the dataset_id (parquet filename stem, e.g. ``ord_dataset-<hex>``)."""
+    return Path(parquet_path).stem
+
+
+def build_configs(repo_root: Path) -> list[dict]:
+    """Build the Hugging Face ``configs`` list from the parquet files on disk.
+
+    Emits a ``default`` config over every dataset except the two large USPTO
+    artifacts, named ``uspto-grants`` and ``uspto-mit`` configs, and one
+    ``ord_dataset-<id>`` config per dataset. Only filenames are read, so no LFS
+    objects need to be present.
+
+    Args:
+        repo_root: Repository root containing the ``data/`` tree.
+
+    Returns:
+        A list of Hugging Face config dicts, ``default`` first.
+    """
+    paths = sorted(
+        p.relative_to(repo_root).as_posix()
+        for p in repo_root.glob("data/*/*.parquet")
+    )
+    by_id = {_dataset_id(p): p for p in paths}
+    named_ids = {USPTO_GRANTS_ID, *USPTO_MIT_SPLITS.values()}
+
+    configs: list[dict] = [
+        {
+            "config_name": "default",
+            "default": True,
+            "data_files": [p for p in paths if _dataset_id(p) not in named_ids],
+        }
+    ]
+    if USPTO_GRANTS_ID in by_id:
+        configs.append(
+            {"config_name": "uspto-grants", "data_files": [by_id[USPTO_GRANTS_ID]]}
+        )
+    if set(USPTO_MIT_SPLITS.values()).issubset(by_id):
+        configs.append(
+            {
+                "config_name": "uspto-mit",
+                "data_files": [
+                    {"split": split, "path": by_id[dataset_id]}
+                    for split, dataset_id in USPTO_MIT_SPLITS.items()
+                ],
+            }
+        )
+    configs += [{"config_name": _dataset_id(p), "data_files": [p]} for p in paths]
+    return configs
+
+
+def build_citation(repo_root: Path) -> str:
+    """Format a BibTeX entry from ``CITATION.cff``'s ``preferred-citation``.
+
+    Args:
+        repo_root: Repository root containing ``CITATION.cff``.
+
+    Returns:
+        A BibTeX ``@article`` entry as a string.
+    """
+    data = yaml.safe_load((repo_root / "CITATION.cff").read_text())
+    ref = data.get("preferred-citation", data)
+    authors = ref.get("authors", [])
+    author_field = " and ".join(
+        f"{a['family-names']}, {a['given-names']}" if "family-names" in a else a["name"]
+        for a in authors
+    )
+    fields = {
+        "author": author_field or None,
+        "title": ref.get("title"),
+        "journal": ref.get("journal"),
+        "year": ref.get("year"),
+        "volume": ref.get("volume"),
+        "number": ref.get("issue"),
+        "pages": (
+            f"{ref['start']}--{ref['end']}"
+            if ref.get("start") and ref.get("end")
+            else None
+        ),
+        "doi": ref.get("doi"),
+    }
+    surname = authors[0].get("family-names", "ord") if authors else "ord"
+    key = f"{surname.split()[0].lower()}{ref.get('year', '')}ord"
+    lines = [f"@article{{{key},"]
+    lines += [f"  {name} = {{{value}}}," for name, value in fields.items() if value]
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def compose_readme(repo_root: Path) -> str:
+    """Compose the mirror README: card front matter, GitHub body, and citation.
+
+    Args:
+        repo_root: Repository root containing ``README.md`` and the dataset.
+
+    Returns:
+        The full Markdown text to upload to Hugging Face as ``README.md``.
+    """
+    metadata = {
+        "license": CARD_LICENSE,
+        "tags": list(CARD_TAGS),
+        "pretty_name": CARD_PRETTY_NAME,
+        "configs": build_configs(repo_root),
+    }
+    front_matter = yaml.safe_dump(
+        metadata, sort_keys=False, allow_unicode=True, default_flow_style=False
+    )
+    body = (repo_root / "README.md").read_text().rstrip()
+    citation = build_citation(repo_root)
+    return (
+        f"---\n{front_matter}---\n\n"
+        f"{body}\n\n"
+        "## Citation\n\n"
+        "If you use this dataset, please cite the Open Reaction Database paper:\n\n"
+        f"```bibtex\n{citation}\n```\n"
     )
 
 
@@ -126,6 +288,15 @@ def main() -> None:
     args = parser.parse_args()
 
     plan = compute_plan(args.base, args.head, args.repo_root)
+    # README is a composed card, uploaded from memory rather than mirrored
+    # verbatim. Track whether its GitHub body changed before dropping it, since
+    # a body-only edit still needs to refresh the card on Hugging Face.
+    readme_changed = "README.md" in plan.uploads
+    plan.uploads = [u for u in plan.uploads if u != "README.md"]
+    has_changes = bool(plan.uploads or plan.deletions or readme_changed)
+    # The config list is derived from all parquet on disk, so any add/delete
+    # can change it; recompose the card whenever there is anything to mirror.
+    composed_readme = compose_readme(args.repo_root) if has_changes else None
 
     print(f"Planned uploads ({len(plan.uploads)}):")
     for p in plan.uploads:
@@ -133,9 +304,11 @@ def main() -> None:
     print(f"Planned deletions ({len(plan.deletions)}):")
     for p in plan.deletions:
         print(f"  - {p}")
-    write_summary(plan, args.summary_file)
+    if composed_readme is not None:
+        print("  + README.md (composed dataset card)")
+    write_summary(plan, composed_readme, args.summary_file)
 
-    if not plan.uploads and not plan.deletions:
+    if not has_changes:
         print("Nothing to mirror.")
         return
     if args.dry_run:
@@ -158,6 +331,11 @@ def main() -> None:
         )
     for path in plan.deletions:
         operations.append(CommitOperationDelete(path_in_repo=path))
+    operations.append(
+        CommitOperationAdd(
+            path_in_repo="README.md", path_or_fileobj=composed_readme.encode()
+        )
+    )
 
     HfApi(token=token).create_commit(
         repo_id=HF_REPO_ID,
@@ -166,8 +344,8 @@ def main() -> None:
         commit_message=args.commit_message,
     )
     print(
-        f"Mirrored {len(plan.uploads)} upload(s) and "
-        f"{len(plan.deletions)} deletion(s) to {HF_REPO_ID}."
+        f"Mirrored {len(plan.uploads) + 1} upload(s) (incl. composed README.md) "
+        f"and {len(plan.deletions)} deletion(s) to {HF_REPO_ID}."
     )
 
 

--- a/scripts/upload_to_huggingface.py
+++ b/scripts/upload_to_huggingface.py
@@ -106,23 +106,23 @@ def compute_plan(base: str, head: str, repo_root: Path) -> DiffPlan:
 
 
 def write_summary(
-    plan: DiffPlan, composed_readme: str | None, path: Path | None
+    uploads: list[str],
+    deletions: list[str],
+    composed_readme: str | None,
+    path: Path | None,
 ) -> None:
     if path is None:
         return
-    uploads_line = f"- Uploads: **{len(plan.uploads)}**"
-    if composed_readme is not None:
-        uploads_line += " + composed `README.md`"
     lines = [
         f"## Hugging Face mirror plan ({HF_REPO_ID})",
         "",
-        uploads_line,
-        f"- Deletions: **{len(plan.deletions)}**",
+        f"- Uploads: **{len(uploads)}**",
+        f"- Deletions: **{len(deletions)}**",
     ]
-    if plan.uploads:
-        lines += ["", "### Uploads", "", "```", *plan.uploads, "```"]
-    if plan.deletions:
-        lines += ["", "### Deletions", "", "```", *plan.deletions, "```"]
+    if uploads:
+        lines += ["", "### Uploads", "", "```", *uploads, "```"]
+    if deletions:
+        lines += ["", "### Deletions", "", "```", *deletions, "```"]
     if composed_readme is not None:
         # Fence with four backticks so the README's own ``` blocks survive.
         lines += [
@@ -298,15 +298,17 @@ def main() -> None:
     # can change it; recompose the card whenever there is anything to mirror.
     composed_readme = compose_readme(args.repo_root) if has_changes else None
 
-    print(f"Planned uploads ({len(plan.uploads)}):")
-    for p in plan.uploads:
+    uploads = list(plan.uploads)
+    if composed_readme is not None:
+        uploads.append("README.md (composed dataset card)")
+
+    print(f"Planned uploads ({len(uploads)}):")
+    for p in uploads:
         print(f"  + {p}")
     print(f"Planned deletions ({len(plan.deletions)}):")
     for p in plan.deletions:
         print(f"  - {p}")
-    if composed_readme is not None:
-        print("  + README.md (composed dataset card)")
-    write_summary(plan, composed_readme, args.summary_file)
+    write_summary(uploads, plan.deletions, composed_readme, args.summary_file)
 
     if not has_changes:
         print("Nothing to mirror.")


### PR DESCRIPTION
Closes #257.

The Hugging Face mirror copied the GitHub `README.md` verbatim, so the HF repo had no dataset-card metadata — the viewer was disabled ("No supported data files found"), `load_dataset("open-reaction-database/ord-data")` failed, and the repo carried no license, tags, or citation. This teaches `scripts/upload_to_huggingface.py` to compose the HF README at upload time: YAML front matter (license, tags, per-dataset configs, and a BibTeX citation) followed by the existing GitHub README body. The card is regenerated on every mirror commit, so its config list always matches the parquet files on disk. The GitHub `README.md` is unchanged — the front matter stays off it so GitHub does not render it as a metadata table.

Configs are generated from each parquet's `dataset_id` (the filename stem), so no LFS objects or footer reads are needed. There is a `default` config (`default: true`) spanning every dataset except the two large USPTO artifacts, a named `uspto-grants` config, a named `uspto-mit` config with real `train`/`validation`/`test` splits (the 10.1039/C8SC04228D reaction-prediction benchmark), and one `ord_dataset-<id>` config per dataset for precise selection — 56 configs in total. Legacy `.pb.gz` objects continue to mirror under `data/**` but are excluded from the configs, since only `*.parquet` is globbed.

The citation is derived from a new `preferred-citation` entry added to `CITATION.cff` for the ORD paper (Kearnes et al., _J. Am. Chem. Soc._ 2021, 143, 18820–18826); the existing Zenodo dataset DOI remains the record's main entry.

Testing: the composed card passes Hugging Face's own metadata validator (`DatasetCard.validate()`), the front matter round-trips as valid YAML, and the PR dry-run path renders the full composed card in the job summary. The two viewer-facing acceptance criteria — the dataset viewer flipping to `viewer: true` and `load_dataset(repo, "<config>")` returning rows — can only be confirmed after the post-merge mirror commit re-indexes the HF repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds generated Hugging Face dataset-card metadata during mirroring.
- Generates default, USPTO, split-specific, and per-dataset configurations from parquet filenames.
- Composes YAML front matter and a BibTeX citation with the existing README body.
- Adds the ORD paper as the preferred citation and PyYAML as a script dependency.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure eligible for this follow-up review remains.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CITATION.cff | Adds the ORD journal article as the preferred citation while retaining the dataset DOI. |
| scripts/requirements.txt | Adds PyYAML for parsing citation metadata and serializing dataset-card front matter. |
| scripts/upload_to_huggingface.py | Generates Hugging Face configurations and citation metadata, composes the mirrored README, and includes it in mirror commits. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Repository parquet files] --> B[Generate dataset configs]
    C[CITATION.cff] --> D[Generate BibTeX citation]
    E[GitHub README] --> F[Compose Hugging Face dataset card]
    B --> F
    D --> F
    F --> G[Upload README with mirror commit]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Print the composed card front matter in ..."](https://github.com/open-reaction-database/ord-data/commit/ae08f767947f4f7fc3874b39eb2dba047cf9f33d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46904667)</sub>

<!-- /greptile_comment -->