### PR TITLE
Insert the missing whitespace in two dataset descriptions

### DIFF
--- a/data/ac/ord_dataset-ac78456835404910b3a4c840248b6ac9.parquet
+++ b/data/ac/ord_dataset-ac78456835404910b3a4c840248b6ac9.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec3befdf2d98c2d122b1e5b8046dfb2bca6b035a1c506c9e1a2ddc4992276d88
-size 126387
+oid sha256:52a9d0084abc051a792bfb71501af03ec13bdabc24a7db4e33b7223ddf8c884c
+size 126388

--- a/data/d3/ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c.parquet
+++ b/data/d3/ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8a81d79136a36e14614f2cf4469f13393d675d6393f07d96f19e569623ac887
-size 30174
+oid sha256:d8f8b29f790e168b7f44dcbdd2ca88829bdaea6be54a31369fd964cf9c01da82
+size 30188


### PR DESCRIPTION
Two descriptions run a reference straight into the sentence that follows it, with no separator:

| Dataset | Description (current) |
| --- | --- |
| `ord_dataset-ac78456835404910b3a4c840248b6ac9` | `https://doi.org/10.1021/acs.accounts.0c00760Data from Figure S12. …` |
| `ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c` | `Ref: Chem. Sci., 2016, 7, 2604.doi: 10.1039/c5sc04751jThis palladium catalyzed …` |

Besides reading badly, this breaks anything that lifts references out of the text — the DOI absorbs the first word of the next sentence and resolves to nothing. This surfaced in ord-interface, which now renders URLs and DOIs in dataset descriptions as links (open-reaction-database/ord-interface#211); these two are the only descriptions in the repository where the extracted link is wrong. Splitting on the case change is not a viable workaround, since mixed-case DOIs like `10.48550/arXiv.2506.07619` are legitimate, so the separator has to be restored here.

The fix inserts whitespace only — no wording, punctuation, or reaction data changes:

- `…0c00760` **+ space +** `Data from Figure S12. …`
- `…2604.` **+ space +** `doi: 10.1039/c5sc04751j` **+ space +** `This palladium catalyzed …`

## How the files were changed

Only the Parquet footer metadata was rewritten; the reaction rows were copied verbatim, so every serialized proto is byte-identical. Verified by hashing all cells before and after the rewrite, and by confirming the row counts (1728 and 264) and all other `ord.*` metadata keys are unchanged. Both files round-trip through `ord_schema.parquet.load_dataset` with the corrected descriptions and pass `validate_dataset.py`.

The `.pb.gz` copies still carry the original text; they are frozen and deprecated, so they are left alone.

Labeled `skip-update-submission`: this is a metadata correction and needs no ID or timestamp assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Corrects malformed references in two dataset descriptions by inserting missing whitespace.
- Updates only the Git LFS-backed Parquet artifacts.
- Separates a DOI URL from the following sentence in the ac dataset description.
- Separates the citation, DOI, and following sentence in the d3 dataset description.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete regressions identified in the changed dataset artifacts.

The changes are narrowly scoped metadata corrections that restore valid reference boundaries without altering the dataset contract or introducing an observable failure.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| data/ac/ord_dataset-ac78456835404910b3a4c840248b6ac9.parquet | Replaces the LFS object with a one-byte-larger Parquet artifact containing the corrected description separator. |
| data/d3/ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c.parquet | Replaces the LFS object with a rewritten Parquet artifact separating the citation, DOI, and subsequent sentence. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Insert the missing whitespace in two dat..."](https://github.com/open-reaction-database/ord-data/commit/9b84eb5d4912a68b7203f71c19d828dab7189adb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47170664)</sub>

<!-- /greptile_comment -->