### PR TITLE
Separate the code license from the data license

### DIFF
--- a/.github/workflows/huggingface_mirror.yml
+++ b/.github/workflows/huggingface_mirror.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Mirrors dataset changes to the Hugging Face dataset
 # open-reaction-database/ord-data.
 #

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Runs process_dataset.py on all new and changed files.
 #
 # Submissions from forks only trigger the "validation" step to validate the new

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,3 +1,17 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Runs process_dataset.py on all files in the database.
 
 name: Validation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run `pre-commit install` once to enable these hooks locally.
+# See https://pre-commit.com.
+repos:
+  # Code in this repository is Apache-2.0 (LICENSE-CODE); the data under data/
+  # is CC-BY-SA-4.0 (LICENSE). This stamps the code license onto source files.
+  - repo: https://github.com/google/addlicense
+    rev: v1.2.0
+    hooks:
+      - id: addlicense
+        args:
+          - -c
+          - Open Reaction Database Project Authors
+          - -l
+          - apache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,16 @@
 # See https://pre-commit.com.
 repos:
   # Code in this repository is Apache-2.0 (LICENSE-CODE); the data under data/
-  # is CC-BY-SA-4.0 (LICENSE). This stamps the code license onto source files.
+  # is CC-BY-SA-4.0 (LICENSE), as are the metadata files that describe it
+  # (README.md, CITATION.cff, CONTRIBUTING.md). Restrict the hook to code so it
+  # cannot stamp the code license onto CC-licensed content: addlicense skips
+  # those files today only because it does not recognize their extensions,
+  # which is not a guarantee worth relying on.
   - repo: https://github.com/google/addlicense
     rev: v1.2.0
     hooks:
       - id: addlicense
+        files: ^(scripts/.*\.py|\.github/.*\.ya?ml|\.pre-commit-config\.yaml)$
         args:
           - -c
           - Open Reaction Database Project Authors

--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -221,3 +221,23 @@ git -c lfs.pushurl=https://github.com/open-reaction-database/ord-data.git/info/l
 
 Reads stay on the mirror; only your uploads go to GitHub. On merge to `main`,
 `huggingface_mirror.yml` copies the new objects to Hugging Face.
+
+## License
+
+This repository carries two licenses, because it holds both data and code:
+
+| what | license | file |
+| --- | --- | --- |
+| The datasets under `data/` (and the repository metadata describing them) | [CC-BY-SA-4.0](LICENSE) | `LICENSE` |
+| The code under `scripts/` and `.github/` | [Apache-2.0](LICENSE-CODE) | `LICENSE-CODE` |
+
+If you are using ORD data, CC-BY-SA-4.0 is the license that applies to you; it
+is what `CITATION.cff` and the [Hugging Face
+mirror](https://huggingface.co/datasets/open-reaction-database/ord-data) declare.
+
+The code carries a separate license because Creative Commons licenses are not
+intended for software — [Creative Commons recommends against
+it](https://creativecommons.org/faq/#can-i-apply-a-creative-commons-license-to-software)
+— and because the project's other code repositories, including
+[ord-schema](https://github.com/Open-Reaction-Database/ord-schema), are
+Apache-2.0.

--- a/scripts/convert_to_parquet.py
+++ b/scripts/convert_to_parquet.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Convert ord-data Dataset protos (.pb.gz) to Parquet, alongside the originals.
 
 Most datasets are converted 1:1 (parquet sibling next to the pb.gz, carrying

--- a/scripts/download_from_huggingface.py
+++ b/scripts/download_from_huggingface.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Download ord-data dataset files from Hugging Face.
 
 Use this as an alternative to `git lfs pull` when Git LFS bandwidth is

--- a/scripts/upload_to_huggingface.py
+++ b/scripts/upload_to_huggingface.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Mirror ord-data changes to the Hugging Face dataset.
 
 Runs `git diff --name-status` between two SHAs, classifies entries into


### PR DESCRIPTION
This repository holds two different kinds of thing under a single `LICENSE`, and only one of them is described correctly today.

The datasets under `data/` are CC-BY-SA-4.0. That is what `CITATION.cff` and the Hugging Face dataset card declare, it is what a data consumer needs to know, and it does not change here. The code under `scripts/` and `.github/` has no license of its own, which leaves it implicitly under the same CC license — a poor fit, since [Creative Commons recommends against](https://creativecommons.org/faq/#can-i-apply-a-creative-commons-license-to-software) applying CC licenses to software, and the project's other code repositories (including [ord-schema](https://github.com/Open-Reaction-Database/ord-schema)) are Apache-2.0. This states the intent that already exists rather than changing direction.

## What this does

`LICENSE` stays CC-BY-SA-4.0 and is untouched, so GitHub's sidebar keeps advertising the data license — the right headline for a data repository. `LICENSE-CODE` adds Apache-2.0 for the code, and a new README section states the split in a table. `addlicense` runs in pre-commit and stamps per-file headers, so a script copied out of the repository carries its license with it rather than depending on a reader finding the right root file.

`LICENSE`/`LICENSE-CODE` is the convention Microsoft uses across its docs and data repositories, where the same split applies (content under CC, code samples under a permissive license). The alternative of a directory-scoped `scripts/LICENSE` was considered and rejected because the code is not only in `scripts/` — `.github/` is code too, and per-directory copies drift.

## Scope

**This changes no code: the diff is 333 insertions and no deletions.** Every modification to an existing file is the 14-line Apache header and nothing else.

A follow-up PR adds Python tooling (uv, ruff, ty, pytest) on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a distinct Apache-2.0 license for repository code while retaining CC-BY-SA-4.0 for datasets and metadata.
- Documents the license split in the README.
- Adds Apache license headers to Python scripts and GitHub workflows.
- Adds a scoped pre-commit hook that applies headers only to designated code files.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .pre-commit-config.yaml | Restricts addlicense to Python scripts, GitHub YAML workflows, and the pre-commit configuration, resolving the prior risk of stamping CC-licensed metadata. |
| README.md | Documents the CC-BY-SA-4.0 data and metadata license alongside the Apache-2.0 code license. |
| LICENSE-CODE | Adds the standard Apache License 2.0 text for repository code. |
| scripts/convert_to_parquet.py | Adds an Apache-2.0 file header without changing executable behavior. |
| scripts/download_from_huggingface.py | Adds an Apache-2.0 file header without changing executable behavior. |
| scripts/upload_to_huggingface.py | Adds an Apache-2.0 file header without changing executable behavior. |
| .github/workflows/huggingface_mirror.yml | Adds an Apache-2.0 file header without changing workflow behavior. |
| .github/workflows/submission.yml | Adds an Apache-2.0 file header without changing workflow behavior. |
| .github/workflows/validation.yml | Adds an Apache-2.0 file header without changing workflow behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Scope the addlicense hook to code files"](https://github.com/open-reaction-database/ord-data/commit/f3800009639f9bb90c1d37aadd4170ab561d77f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47317445)</sub>

<!-- /greptile_comment -->