### PR TITLE
Accept .binpb and .txtpb dataset submissions

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -34,6 +34,15 @@ concurrency:
   group: submission-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  # Dataset files a submission may contain: protobuf binary (.pb/.binpb) or
+  # text (.pbtxt/.txtpb), either optionally gzipped, plus Parquet. The
+  # check_file_types job rejects anything else, and process_submission selects
+  # the files it processes with the same pattern, so they must agree: a
+  # suffix accepted by one but not the other either fails a legitimate
+  # submission or silently processes nothing.
+  DATASET_FILE_PATTERN: '\.(pb|binpb|pbtxt|txtpb)(\.gz)?$|\.parquet$'
+
 jobs:
   check_file_types:
     runs-on: ubuntu-latest
@@ -51,8 +60,8 @@ jobs:
       run: |
         cd "${GITHUB_WORKSPACE}"
         git diff --name-only upstream/main > changed_files.txt
-        grep -vE '\.(pb(txt)?(.gz)?|parquet)$' changed_files.txt && \
-          echo "Error: submissions should only contain (gzipped) *.pbtxt, *.pb, or *.parquet files" && \
+        grep -vE "${DATASET_FILE_PATTERN}" changed_files.txt && \
+          echo "Error: submissions should only contain *.pb, *.binpb, *.pbtxt, or *.txtpb files (optionally gzipped), or *.parquet files" && \
           exit 1 || true
       if: github.event.pull_request.head.repo.fork
 
@@ -93,7 +102,7 @@ jobs:
         echo "Found $(wc -l < changed_files.txt | tr -d ' ') changed files"
         cat changed_files.txt
         # Use `|| (( $? == 1 ))` in case no lines match (exit code is nonzero).
-        grep -E "\.(pb(txt)?(.gz)?|parquet)$" changed_files.txt > changed_data_files.txt || (( $? == 1 ))
+        grep -E "${DATASET_FILE_PATTERN}" changed_files.txt > changed_data_files.txt || (( $? == 1 ))
         # Use LOCAL_NUM_CHANGED since ::set-env values are not available immediately.
         LOCAL_NUM_CHANGED="$(wc -l < changed_data_files.txt | tr -d ' ')"
         echo "NUM_CHANGED_FILES=${LOCAL_NUM_CHANGED}" >> $GITHUB_ENV

--- a/scripts/process_dataset.py
+++ b/scripts/process_dataset.py
@@ -30,7 +30,6 @@ should validate with ord_schema.scripts.validate_dataset instead.
 import argparse
 import dataclasses
 import glob
-import gzip
 import os
 import pathlib
 import subprocess
@@ -140,6 +139,24 @@ def _get_reaction_ids(
     }
 
 
+def _dataset_suffix(filename: str) -> str:
+    """Returns the suffix that determines a dataset file's serialization format.
+
+    Args:
+        filename: Dataset filename, e.g. ``data/4d/ord_dataset-abc.pb.gz``.
+
+    Returns:
+        The format-bearing suffix, keeping a trailing ``.gz``: e.g. ``.pb.gz``,
+        ``.binpb``, or ``.parquet``. Empty if the filename has no suffix.
+    """
+    suffixes = pathlib.Path(filename).suffixes
+    if not suffixes:
+        return ""
+    if suffixes[-1] == ".gz":
+        return "".join(suffixes[-2:])
+    return suffixes[-1]
+
+
 def _load_base_dataset(
     file_status: FileStatus, base: str
 ) -> dataset_pb2.Dataset | parquet.DatasetView | None:
@@ -170,16 +187,20 @@ def _load_base_dataset(
             check=True,
             text=False,
         )
-    if git_args[-1].endswith(".parquet"):
+    suffix = _dataset_suffix(git_args[-1])
+    if suffix == ".parquet":
         with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as temp:
             temp.write(serialized.stdout)
             temp_path = temp.name
         return parquet.DatasetView(temp_path)
-    if git_args[-1].endswith(".gz"):
-        value = gzip.decompress(serialized.stdout)
-    else:
-        value = serialized.stdout
-    return dataset_pb2.Dataset.FromString(value)
+    # load_message picks the parser from the suffix, so the temp file has to keep
+    # it: .pb/.binpb parse as binary, .pbtxt/.txtpb as text, and a trailing .gz
+    # decompresses either. This copy is read before the file is closed, so unlike
+    # the Parquet view above it does not need to outlive the block.
+    with tempfile.NamedTemporaryFile(suffix=suffix) as temp:
+        temp.write(serialized.stdout)
+        temp.flush()
+        return message_helpers.load_message(temp.name, dataset_pb2.Dataset)
 
 
 def get_change_stats(

--- a/scripts/process_dataset_test.py
+++ b/scripts/process_dataset_test.py
@@ -309,7 +309,15 @@ class TestSubmissionWorkflow:
         """
         # These commands will fail if there are no files to match for a given
         # pattern, so run them separately to make sure we pick up changes.
-        for pattern in ("*.pb*", "data/*/*.pb*", "*.parquet", "data/*/*.parquet"):
+        for pattern in (
+            "*.pb*",
+            "data/*/*.pb*",
+            # .binpb/.txtpb have no ".pb" substring, so *.pb* does not cover them.
+            "*.binpb*",
+            "*.txtpb*",
+            "*.parquet",
+            "data/*/*.parquet",
+        ):
             try:
                 subprocess.run(["git", "add", pattern], check=True)
             except subprocess.CalledProcessError as error:
@@ -376,6 +384,43 @@ class TestSubmissionWorkflow:
         assert len(dataset.reactions) == 1
         assert dataset.reactions[0].reaction_id
         # Check for binary output.
+        assert filenames[0].endswith(".pb.gz")
+
+    @pytest.mark.parametrize("suffix", [".binpb", ".txtpb"])
+    def test_add_dataset_with_protobuf_canonical_suffix(self, setup, suffix):
+        # A submission staged at the repository root using protobuf.dev's
+        # canonical suffixes, as in ord-data#265.
+        test_subdirectory, dataset_filename = setup
+        reaction = reaction_pb2.Reaction()
+        ethylamine = reaction.inputs["ethylamine"]
+        component = ethylamine.components.add()
+        component.identifiers.add(type="SMILES", value="CCN")
+        component.is_limiting = True
+        component.amount.moles.value = 2
+        component.amount.moles.units = reaction_pb2.Moles.MILLIMOLE
+        reaction.outcomes.add().conversion.value = 25
+        reaction.provenance.record_created.time.value = "2020-01-01"
+        reaction.provenance.record_created.person.username = "test"
+        reaction.provenance.record_created.person.email = "test@example.com"
+        reaction.reaction_id = "test"
+        dataset = dataset_pb2.Dataset(
+            name="test", description="test", reactions=[reaction]
+        )
+        this_dataset_filename = pathlib.Path(test_subdirectory) / f"test{suffix}"
+        message_helpers.save_message(dataset, this_dataset_filename)
+        added, removed, changed, filenames = self._run(test_subdirectory)
+        assert added == {"test"}
+        assert not removed
+        assert not changed
+        # The submission is rewritten into data/ and the root input is gone.
+        assert not this_dataset_filename.exists()
+        assert len(filenames) == 2
+        filenames.pop(filenames.index(dataset_filename))
+        written = message_helpers.load_message(filenames[0], dataset_pb2.Dataset)
+        assert written.dataset_id
+        assert len(written.reactions) == 1
+        assert written.reactions[0].reaction_id
+        # Submissions are normalized to the canonical on-disk format.
         assert filenames[0].endswith(".pb.gz")
 
     def test_add_parquet_dataset_with_cleanup(self, setup):
@@ -639,3 +684,73 @@ class TestSubmissionWorkflow:
         assert len(removed) == 1
         assert not changed
         assert len(filenames) == 1
+
+
+class TestDatasetSuffix:
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("dataset.pb", ".pb"),
+            ("dataset.binpb", ".binpb"),
+            ("dataset.pbtxt", ".pbtxt"),
+            ("dataset.txtpb", ".txtpb"),
+            ("dataset.parquet", ".parquet"),
+            ("data/4d/ord_dataset-abc.pb.gz", ".pb.gz"),
+            ("dataset.binpb.gz", ".binpb.gz"),
+            ("dataset.txtpb.gz", ".txtpb.gz"),
+            # Dots earlier in the basename are not part of the format suffix.
+            ("Dreher_exp1.revised.binpb", ".binpb"),
+            ("dataset", ""),
+        ],
+    )
+    def test_dataset_suffix(self, filename, expected):
+        assert process_dataset._dataset_suffix(filename) == expected
+
+
+class TestLoadBaseDataset:
+    """Covers the format dispatch used to read a file's base revision out of git.
+
+    Text formats are the reason this matters: parsing a .pbtxt/.txtpb base revision
+    as binary silently fails, so every accepted suffix is round-tripped here.
+    """
+
+    @pytest.mark.parametrize(
+        "suffix",
+        [".pb", ".binpb", ".pbtxt", ".txtpb", ".pb.gz", ".binpb.gz", ".txtpb.gz"],
+    )
+    def test_reads_base_revision(self, tmp_path, monkeypatch, suffix):
+        monkeypatch.chdir(tmp_path)
+        subprocess.run(["git", "init", "-b", "main"], check=True)
+        subprocess.run(
+            ["git", "config", "--local", "user.email", "test@ord-schema"], check=True
+        )
+        subprocess.run(
+            ["git", "config", "--local", "user.name", "Test Runner"], check=True
+        )
+        base = dataset_pb2.Dataset(
+            name="base",
+            description="base",
+            dataset_id="ord_dataset-64b14868c5cd46dd8e75560fd3589a6b",
+        )
+        filename = f"dataset{suffix}"
+        message_helpers.save_message(base, filename)
+        subprocess.run(["git", "add", filename], check=True)
+        subprocess.run(["git", "commit", "-m", "Initial commit"], check=True)
+        # Overwrite the working copy: the committed revision is now the only
+        # place the original name survives, so a wrong parse cannot pass.
+        message_helpers.save_message(dataset_pb2.Dataset(name="modified"), filename)
+        loaded = process_dataset._load_base_dataset(
+            process_dataset.FileStatus(filename, "M", ""), "main"
+        )
+        assert loaded is not None  # Only added ("A") files have no base revision.
+        assert loaded.name == "base"
+        assert loaded.description == "base"
+        assert loaded.dataset_id == base.dataset_id
+
+    def test_added_file_has_no_base_revision(self):
+        assert (
+            process_dataset._load_base_dataset(
+                process_dataset.FileStatus("dataset.binpb", "A", ""), "main"
+            )
+            is None
+        )


### PR DESCRIPTION
protobuf.dev's canonical suffixes for the binary and text wire formats are `.binpb` and `.txtpb`, but submissions were restricted to `.pb`/`.pbtxt`/`.parquet`. A dataset saved under the newer names is rejected, which is what blocks [#265](https://github.com/open-reaction-database/ord-data/pull/265).

## The pattern was written out twice, and the copies disagreed with each other in effect

`check_file_types` used it to reject non-dataset files; `process_submission` used an identical copy to build `changed_data_files.txt`. On #265 that produced two different-looking failures from one cause: `check_file_types` failed loudly, while `process_submission` reported **success** having done nothing at all — the same pattern filtered both `.binpb` files out, so `NUM_CHANGED_FILES` was `0` and every subsequent step was skipped by its `if:` guard. The log reads `Found 11 changed files` then `Found 0 changed dataset files`.

A green check that silently processed nothing is the worse of the two failures, so the pattern is now a single workflow-level `DATASET_FILE_PATTERN` that both jobs read. The two cannot drift apart again, and a suffix accepted by one but not the other is no longer expressible.

The pattern also escapes the dot in `(\.gz)?`. Unescaped, it matched any character, so `foo.pbXgz` was accepted as a dataset file.

## Base revisions of text-format files were parsed as binary

`_load_base_dataset` reads the pre-submission revision out of git to compute added/removed reaction counts. It special-cased `.parquet`, gunzipped anything ending in `.gz`, and then called `Dataset.FromString` on the result — a binary parse applied to every non-Parquet input, including `.pbtxt`. That is a latent bug on the existing `.pbtxt` suffix, not something `.txtpb` introduces; it just widens with the new suffix.

It now spills the bytes to a temp file that keeps the original suffix and hands off to `message_helpers.load_message`, which already dispatches on suffix and handles `.gz` for either format. That deletes the local gzip and format handling rather than extending it. Unlike the Parquet view alongside it, this temp file is read before the block exits, so it does not need to outlive it.

## Verification

`TestLoadBaseDataset` round-trips all seven accepted suffixes through a real git commit, overwriting the working copy first so the committed revision is the only surviving source of the original metadata — a wrong parse cannot pass. Reverting just the `_load_base_dataset` change fails exactly the three text cases (`.pbtxt`, `.txtpb`, `.txtpb.gz`) and passes the four binary ones.

`test_add_dataset_with_protobuf_canonical_suffix` reproduces #265 end to end: a dataset staged at the repository root as `.binpb`/`.txtpb`, processed with `--update --cleanup`, landing under `data/` as `.pb.gz` with IDs assigned and the root input removed. Submissions are still normalized to the canonical on-disk format, so nothing changes about what `data/` holds; `.gitattributes` needs no new LFS pattern for the same reason.

All four pre-commit hooks pass; 50 tests pass under `pytest -n auto` (up from 30).

## Note on #265

This unblocks the file-type failure only. That PR also fails `check_target_branch`, which requires fork submissions to target a branch other than `main` — it will need retargeting regardless of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR accepts protobuf’s canonical `.binpb` and `.txtpb` dataset suffixes while keeping workflow validation and processing selection synchronized.
- Defines one workflow-level dataset filename pattern used by both submission checks.
- Loads base protobuf datasets through suffix-aware `message_helpers.load_message`.
- Adds end-to-end and base-revision coverage for the newly supported formats and compressed variants.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The shared workflow pattern remains end-anchored and is applied consistently, while base revisions are loaded according to the original file’s preserved serialization suffix and the new formats receive focused regression coverage.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/submission.yml | Centralizes the accepted dataset suffix regex and uses it consistently for validation and processing selection. |
| scripts/process_dataset.py | Replaces binary-only base protobuf parsing with suffix-aware loading that handles text, binary, and compressed formats. |
| scripts/process_dataset_test.py | Adds canonical-suffix workflow tests plus suffix extraction and committed base-revision round-trip coverage. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PR as Submission PR
    participant WF as submission.yml
    participant PD as process_dataset.py
    participant MH as message_helpers
    PR->>WF: Changed dataset files
    WF->>WF: Validate and select with DATASET_FILE_PATTERN
    WF->>PD: Process accepted files
    PD->>PD: Read base revision from git
    PD->>MH: Load temp file using preserved suffix
    MH-->>PD: Parsed Dataset
    PD-->>PR: Normalize output under data/ as .pb.gz
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Accept .binpb and .txtpb dataset submiss..."](https://github.com/open-reaction-database/ord-data/commit/3c911066c4bbe288bf75817dce25d622a85736db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49414503)</sub>

<!-- /greptile_comment -->