### PR TITLE
Retarget fork data submissions onto their own branch automatically

### DIFF
--- a/.github/workflows/retarget_submission.yml
+++ b/.github/workflows/retarget_submission.yml
@@ -93,8 +93,16 @@ jobs:
         if gh api --method POST "repos/${REPO}/git/refs" \
              -f "ref=refs/heads/${BRANCH}" -f "sha=${SHA}" >/dev/null 2>&1; then
           echo "Created ${BRANCH} at ${SHA}"
+        # A submission closed and reopened after main moved on would otherwise
+        # be compared against a branch cut from an older main. force=false
+        # makes this a fast-forward or nothing, so a branch that already
+        # carries a merged submission is left exactly as it is. Here the ref is
+        # in the URL, where "#" has to be escaped.
+        elif gh api --method PATCH "repos/${REPO}/git/refs/heads/%23${PR_NUMBER}" \
+               -f "sha=${SHA}" -F "force=false" >/dev/null 2>&1; then
+          echo "Fast-forwarded the existing ${BRANCH} to ${SHA}"
         else
-          echo "${BRANCH} already exists; reusing it"
+          echo "Reusing ${BRANCH} unchanged; it carries commits of its own"
         fi
         # Authoritative step: if the branch could not be created above, this
         # fails loudly rather than leaving the submission pointed at main.

--- a/.github/workflows/retarget_submission.yml
+++ b/.github/workflows/retarget_submission.yml
@@ -33,9 +33,12 @@ name: Retarget Submission
 # only ever used for GitHub API calls about the pull request; this workflow
 # checks out no code at all, and in particular never checks out the fork's head,
 # so nothing the contributor controls is read or executed here.
+# `edited` fires when a base branch is changed, so a submission pointed back at
+# main by hand is moved again. This cannot recurse: the repoint below is made
+# with GITHUB_TOKEN, and events from that token start no workflow run.
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
 
 permissions:
   contents: write        # create the "#<number>" branch

--- a/.github/workflows/retarget_submission.yml
+++ b/.github/workflows/retarget_submission.yml
@@ -1,0 +1,112 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Points fork data submissions at an ord-owned "#<number>" branch.
+#
+# submission.yml's "Update submission" step pushes processed commits (reaction
+# IDs, timestamps, the move into data/) back to the pull request's branch, and
+# GitHub Actions cannot push to a contributor's fork: a `pull_request` run from
+# a fork gets a read-only GITHUB_TOKEN, and even a writable token is scoped to
+# this repository rather than the fork. Submissions are therefore merged into a
+# branch here first, and that branch is what opens the pull request against
+# main. This workflow creates the branch and repoints the submission at it so
+# contributors do not have to know the convention.
+#
+# Fork pull requests that touch no dataset files are ordinary contributions
+# (documentation, workflows, scripts) and keep targeting main.
+
+name: Retarget Submission
+
+# pull_request_target runs in the context of the base repository, which is what
+# makes a writable token available on a pull request from a fork. That token is
+# only ever used for GitHub API calls about the pull request; this workflow
+# checks out no code at all, and in particular never checks out the fork's head,
+# so nothing the contributor controls is read or executed here.
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: write        # create the "#<number>" branch
+  pull-requests: write   # repoint the pull request and comment on it
+
+concurrency:
+  group: retarget-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  # Keep identical to submission.yml; tests.yml fails if the two drift. Defined
+  # in the workflow rather than read from a file because a `pull_request` run
+  # checks out the merge ref: a file would be the fork's copy, and weakening it
+  # to `.*` would defeat check_file_types.
+  DATASET_FILE_PATTERN: '\.(pb|binpb|pbtxt|txtpb)(\.gz)?$|\.parquet$'
+
+jobs:
+  retarget:
+    if: >-
+      github.event.pull_request.head.repo.fork &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Retarget a data submission to an ord-owned branch
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Passed through the environment rather than interpolated into the
+        # script. The number is an integer from GitHub, but keeping all event
+        # data out of the script text is the habit that makes injection
+        # impossible rather than merely unlikely.
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        # Collected before matching rather than piped straight into grep: under
+        # pipefail, `gh | grep -q` can report the SIGPIPE from grep's early exit
+        # on a match, which would read as "no dataset files".
+        FILES="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+          --jq '.[].filename')"
+        # Filenames come from the pull request and are untrusted, so they are
+        # only ever matched against the pattern -- never evaluated.
+        if ! printf '%s\n' "${FILES}" | grep -qE "${DATASET_FILE_PATTERN}"; then
+          echo "No dataset files changed; leaving this pull request on main."
+          exit 0
+        fi
+        BRANCH="#${PR_NUMBER}"
+        echo "Data submission detected; retargeting onto ${BRANCH}"
+        # Branch from main's current tip so repointing does not change the diff.
+        SHA="$(gh api "repos/${REPO}/git/ref/heads/main" --jq '.object.sha')"
+        # Idempotent: reopening a pull request finds the branch already there.
+        # The ref name goes in the request body, so "#" needs no URL escaping.
+        if gh api --method POST "repos/${REPO}/git/refs" \
+             -f "ref=refs/heads/${BRANCH}" -f "sha=${SHA}" >/dev/null 2>&1; then
+          echo "Created ${BRANCH} at ${SHA}"
+        else
+          echo "${BRANCH} already exists; reusing it"
+        fi
+        # Authoritative step: if the branch could not be created above, this
+        # fails loudly rather than leaving the submission pointed at main.
+        gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" \
+          -f "base=${BRANCH}" >/dev/null
+        gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file - <<EOF
+        Thanks for the submission! I have retargeted this pull request onto
+        \`${BRANCH}\`, a branch in this repository, because it adds or changes
+        dataset files.
+
+        Submissions are merged into a branch here first so the submission
+        workflow can push the processed dataset back to it -- assigning reaction
+        and dataset IDs and moving files into \`data/\` -- which GitHub Actions
+        cannot do on a fork. Once this merges, \`${BRANCH}\` opens a second pull
+        request against \`main\`.
+
+        Nothing is required from you, and the diff is unchanged.
+        EOF

--- a/.github/workflows/retarget_submission.yml
+++ b/.github/workflows/retarget_submission.yml
@@ -95,14 +95,28 @@ jobs:
           echo "Created ${BRANCH} at ${SHA}"
         # A submission closed and reopened after main moved on would otherwise
         # be compared against a branch cut from an older main. force=false
-        # makes this a fast-forward or nothing, so a branch that already
-        # carries a merged submission is left exactly as it is. Here the ref is
-        # in the URL, where "#" has to be escaped.
+        # makes this a fast-forward or nothing, so a branch carrying commits of
+        # its own is never rewritten. Here the ref is in the URL, where "#" has
+        # to be escaped.
         elif gh api --method PATCH "repos/${REPO}/git/refs/heads/%23${PR_NUMBER}" \
                -f "sha=${SHA}" -F "force=false" >/dev/null 2>&1; then
           echo "Fast-forwarded the existing ${BRANCH} to ${SHA}"
+        # Reached only when the branch has commits of its own -- an earlier
+        # submission already merged into it -- so no fast-forward is possible.
+        # Merging brings main in without rewriting that history, which keeps
+        # the base from being an old main. 204 (already up to date) counts as
+        # success here just as 201 does.
+        elif gh api --method POST "repos/${REPO}/merges" \
+               -f "base=${BRANCH}" -f "head=main" \
+               -f "commit_message=Merge main into ${BRANCH}" >/dev/null 2>&1; then
+          echo "Merged main into the existing ${BRANCH}"
         else
-          echo "Reusing ${BRANCH} unchanged; it carries commits of its own"
+          # A conflict between main and an already-merged submission. Retarget
+          # anyway: leaving the pull request on main is worse, and the conflict
+          # has to be resolved on the "${BRANCH}" -> main pull request either
+          # way.
+          echo "::warning::Could not bring main into ${BRANCH}; it conflicts" \
+            "and needs resolving before ${BRANCH} can merge to main."
         fi
         # Authoritative step: if the branch could not be created above, this
         # fails loudly rather than leaving the submission pointed at main.

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -25,8 +25,10 @@ on:
   pull_request:
     # Default trigger types plus labeled/unlabeled so adding or removing the
     # `skip-update-submission` label re-runs the workflow with the new
-    # gating on the "Update submission" step.
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    # gating on the "Update submission" step, and edited so that
+    # retarget_submission.yml moving a submission off main re-runs these checks
+    # against the new base. Jobs ignore edits that did not change the base.
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
 # One in-flight run per PR. New events (pushes, label toggles) cancel
 # the prior run so we are not paying twice for things like LFS checkouts.
@@ -37,14 +39,24 @@ concurrency:
 env:
   # Dataset files a submission may contain: protobuf binary (.pb/.binpb) or
   # text (.pbtxt/.txtpb), either optionally gzipped, plus Parquet. The
-  # check_file_types job rejects anything else, and process_submission selects
-  # the files it processes with the same pattern, so they must agree: a
-  # suffix accepted by one but not the other either fails a legitimate
-  # submission or silently processes nothing.
+  # check_file_types job rejects anything else, check_target_branch decides
+  # whether a fork's pull request is a data submission, and process_submission
+  # selects the files it processes -- all with this pattern, so they must
+  # agree: a suffix accepted by one but not the others either fails a
+  # legitimate submission or silently processes nothing.
+  #
+  # retarget_submission.yml carries the same value and tests.yml fails if the
+  # two drift. It cannot be shared through a file because a `pull_request` run
+  # checks out the merge ref, so the file would be the fork's copy and
+  # weakening it to `.*` would defeat check_file_types.
   DATASET_FILE_PATTERN: '\.(pb|binpb|pbtxt|txtpb)(\.gz)?$|\.parquet$'
 
 jobs:
   check_file_types:
+    # An edit that left the base alone (a retitled pull request, say) changes
+    # nothing these jobs look at. process_submission needs this job, so
+    # skipping here skips the LFS checkout below it too.
+    if: github.event.action != 'edited' || github.event.changes.base
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -66,13 +78,42 @@ jobs:
       if: github.event.pull_request.head.repo.fork
 
   check_target_branch:
-    if: github.event.pull_request.head.repo.fork
+    # A data submission from a fork must not target main: the Update submission
+    # step cannot push processed commits back to a fork, so submissions are
+    # merged into an ord-owned "#<number>" branch first and that branch opens
+    # the pull request against main. retarget_submission.yml does this move
+    # automatically, so failing here means it did not run or could not finish.
+    #
+    # Fork pull requests that change no dataset files are ordinary
+    # contributions -- documentation, workflows, scripts -- and target main
+    # like any other.
+    if: >-
+      github.event.pull_request.head.repo.fork &&
+      (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-latest
     steps:
     - name: Check target branch
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
       run: |
+        set -euo pipefail
         echo "Target branch: ${GITHUB_BASE_REF}"
-        test "${GITHUB_BASE_REF}" != "main"
+        if [[ "${GITHUB_BASE_REF}" != "main" ]]; then
+          exit 0
+        fi
+        # Collected before matching: under pipefail, `gh | grep -q` can report
+        # the SIGPIPE from grep's early exit on a match.
+        FILES="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+          --jq '.[].filename')"
+        if printf '%s\n' "${FILES}" | grep -qE "${DATASET_FILE_PATTERN}"; then
+          echo "Error: a data submission from a fork cannot target main; it" \
+            "belongs on a '#${PR_NUMBER}' branch in this repository so the" \
+            "submission workflow can push the processed dataset back to it."
+          exit 1
+        fi
+        echo "No dataset files changed; targeting main is fine."
 
   process_submission:
     # This job runs scripts/process_dataset.py from the pull request's own

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -87,8 +87,16 @@ jobs:
     # Fork pull requests that change no dataset files are ordinary
     # contributions -- documentation, workflows, scripts -- and target main
     # like any other.
+    #
+    # Deliberately not run on opened/reopened, where retarget_submission.yml is
+    # already moving the submission: it repoints with GITHUB_TOKEN, and events
+    # from that token start no workflow run, so a failure recorded here would
+    # never be re-run and would sit red on a pull request that had in fact been
+    # fixed seconds later. Every later event still checks.
     if: >-
       github.event.pull_request.head.repo.fork &&
+      github.event.action != 'opened' &&
+      github.event.action != 'reopened' &&
       (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ on:
       - 'uv.lock'
       - '.python-version'
       - '.github/workflows/tests.yml'
+      # Both carry DATASET_FILE_PATTERN, compared by the step below.
+      - '.github/workflows/submission.yml'
+      - '.github/workflows/retarget_submission.yml'
 
 permissions:
   contents: read
@@ -54,3 +57,18 @@ jobs:
       run: uv run ty check
     - name: pytest
       run: uv run pytest -n auto -ra
+    - name: Dataset file pattern agrees across workflows
+      # submission.yml and retarget_submission.yml must classify dataset files
+      # identically; a suffix accepted by one but not the other either fails a
+      # legitimate submission or silently processes nothing. The value cannot
+      # be shared through a file, because a `pull_request` run checks out the
+      # merge ref and a fork could weaken its copy, so it is declared in both
+      # and compared here.
+      run: |
+        set -euo pipefail
+        DEFINITIONS="$(grep -h '^  DATASET_FILE_PATTERN:' \
+          .github/workflows/submission.yml \
+          .github/workflows/retarget_submission.yml)"
+        echo "${DEFINITIONS}"
+        test "$(printf '%s\n' "${DEFINITIONS}" | wc -l)" -eq 2
+        test "$(printf '%s\n' "${DEFINITIONS}" | sort -u | wc -l)" -eq 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,13 @@ Excellent! Please follow the
 [Submission Workflow](https://ord-schema.readthedocs.io/en/latest/submissions.html)
 in the documentation.
 
+**Note on the target branch:** open your pull request against `main`. If it adds
+or changes dataset files, a workflow moves it onto a `#<number>` branch in this
+repository and comments to say so — your diff is unchanged and nothing is
+required from you. That branch exists because the submission workflow pushes the
+processed dataset back (assigning reaction and dataset IDs, moving files into
+`data/`), which GitHub Actions cannot do on a fork.
+
 **Note on large files (Git LFS):** Published datasets under `data/` are stored
 with [Git LFS](https://git-lfs.com/), and clones fetch the objects from the
 [Hugging Face mirror](https://huggingface.co/datasets/open-reaction-database/ord-data)


### PR DESCRIPTION
## Summary

A fork submission has to reach `main` through an ord-owned `#<number>` branch, because "Update submission" pushes processed commits back to the pull request's branch and Actions cannot push to a fork. Creating that branch and repointing the pull request was manual, so contributors who did not know the convention hit a failing check first, as on #265. This does it automatically, recognizing a data submission with the `DATASET_FILE_PATTERN` from #266.

## Changes

- Add `retarget_submission.yml`: create `#<number>` at main's tip, repoint the base, comment. Idempotent, and a reused branch is brought up to date — fast-forwarded when it has no commits of its own, merged from `main` when it does, so the base is never an old `main`.
- Scope `check_target_branch` to data submissions. It fired on every fork pull request, so a README fix from a fork was pushed onto a submission branch for no reason.
- Stop running `check_target_branch` on `opened`/`reopened`, where the retarget is already handling it. The repoint uses `GITHUB_TOKEN`, whose events start no workflow run, so a failure recorded there could never be cleared.
- Add `edited` to both workflows so a submission repointed at `main` by hand is caught and moved again.
- Note the automatic retarget in `CONTRIBUTING.md`.

## Testing

- Both `run:` scripts extracted from the parsed YAML and executed against a stubbed `gh`. The retarget emits exactly the intended calls (`ref=refs/heads/#265` in the body, `base=#265`), takes the fast-forward and leave-alone paths correctly, and exits without retargeting when no dataset files are present. `check_target_branch` passes when already retargeted, fails a data submission on `main`, and passes a docs-only fork pull request on `main`.
- The `edited` guard was confirmed live: editing this pull request's body triggered a run in which all three jobs reported `skipping`.
- `tests.yml` compares the two `DATASET_FILE_PATTERN` declarations; verified it passes as written and fails when one is altered.

## Notes

`pull_request_target` is needed for a writable token on a fork's pull request. This job **checks out nothing at all**, so no fork-controlled file is read or executed; filenames are only ever matched against the pattern, never evaluated.

Kept as a second workflow rather than more jobs in `submission.yml`: one file can declare both triggers, but every job then runs for both events unless individually gated, and `process_submission` executes `scripts/process_dataset.py` from the fork's own checkout. Under `pull_request_target` that would run fork-authored code with a writable token and secrets in scope.

`DATASET_FILE_PATTERN` is declared in both workflows rather than shared through a file: a `pull_request` run checks out the merge ref, so `check_file_types` would read the fork's copy and a submission weakening it to `.*` would pass its own file-type check.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR automatically retargets fork-based data submissions from `main` to repository-owned `#<number>` branches while leaving ordinary fork contributions on `main`.
- Adds a privileged, checkout-free workflow that identifies dataset changes, creates or refreshes the repository-owned branch, retargets the pull request, and comments with an explanation.
- Narrows target-branch enforcement to data submissions and coordinates workflow triggers around retargeting.
- Adds a CI check ensuring dataset filename patterns remain synchronized across workflows.
- Documents automatic retargeting for contributors.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge.

No blocking failure remains, and the previously reported stale existing-branch issue is addressed by fast-forwarding or merging current `main` before retargeting.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/retarget_submission.yml | Adds checkout-free detection and retargeting of fork data submissions, including idempotent branch creation and synchronization with `main`. |
| .github/workflows/submission.yml | Limits target-branch enforcement to fork data submissions and adjusts event handling to coexist with automatic retargeting. |
| .github/workflows/tests.yml | Runs tests when either workflow changes and verifies that both workflows use the same dataset filename pattern. |
| CONTRIBUTING.md | Explains the automatic two-stage branch workflow for fork data submissions. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Contributor fork PR
    participant R as Retarget workflow
    participant B as Repository #number branch
    participant S as Submission workflow
    participant M as main
    C->>R: Open or reopen data submission targeting main
    R->>R: Inspect changed filenames via GitHub API
    R->>B: Create at main tip or refresh from main
    R->>C: "Change PR base to #number and comment"
    C->>B: Maintainer merges submission
    S->>B: Process and push dataset updates
    B->>M: Open final pull request
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Bring main into a diverged submission br..."](https://github.com/open-reaction-database/ord-data/commit/366bc3d7f08e617eb5a661ea185522dc20a0020c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49415589)</sub>

<!-- /greptile_comment -->