### PR TITLE
Run the submission pipeline from the base branch

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -124,9 +124,11 @@ jobs:
         echo "No dataset files changed; targeting main is fine."
 
   process_submission:
-    # This job runs scripts/process_dataset.py from the pull request's own
-    # checkout, so it must not start until check_file_types has confirmed that a
-    # fork's submission contains dataset files and nothing else.
+    # Ordered after check_file_types so a fork submission carrying anything but
+    # dataset files is reported as that, rather than as whatever the pipeline
+    # makes of an unexpected file. The pipeline itself comes from the base
+    # branch (see below), so this ordering is no longer what stands between a
+    # fork and code execution.
     needs: check_file_types
     runs-on: ubuntu-latest
     steps:
@@ -194,20 +196,43 @@ jobs:
         INCLUDE="$(awk '{print $NF}' changed_data_files.txt | paste -sd, -)"
         echo "Pulling LFS objects for changed datasets: ${INCLUDE}"
         git lfs pull --include="${INCLUDE}"
+    # The pipeline runs from the base branch, never from the checkout above.
+    # That checkout is the pull request's own, so on a fork both
+    # process_dataset.py and uv.lock are contributor-controlled: executing the
+    # one or resolving dependencies from the other would run whatever the
+    # submission happened to carry. check_file_types rejects a fork submission
+    # touching anything but dataset files, but that is a policy check standing
+    # in front of code execution rather than a boundary. Datasets still come
+    # from the pull request; only the code that processes them does not.
+    #
+    # Nested inside the workspace because process_dataset.py has to run with
+    # the pull request's working tree as its cwd -- it shells out to git show,
+    # git diff, git mv, and git rm against it. The directory is untracked, which
+    # neither `git diff` against upstream/main nor `git commit -a` picks up.
+    - name: Check out the pipeline from the base branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: pipeline
+        lfs: false
+      if: env.NUM_CHANGED_FILES != '0'
     - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         enable-cache: true
       if: env.NUM_CHANGED_FILES != '0'
     # process_dataset.py needs the schema library and pygithub; --only-group
-    # skips the project's own runtime deps and the lint/test toolchain. The
-    # runs below pass --no-sync so they use exactly this environment.
+    # skips the project's own runtime deps and the lint/test toolchain.
     - name: Install dependencies
+      working-directory: pipeline
       run: uv sync --only-group pipeline --locked
       if: env.NUM_CHANGED_FILES != '0'
+    # The interpreter is invoked directly rather than through `uv run`, which
+    # would rediscover the pull request's own pyproject.toml from the working
+    # directory and put the fork back in control of the environment.
     - name: Validate submission
       run: |
         cd "${GITHUB_WORKSPACE}"
-        uv run --no-sync python scripts/process_dataset.py \
+        ./pipeline/.venv/bin/python ./pipeline/scripts/process_dataset.py \
           --input_file=changed_data_files.txt \
           --base=upstream/main
       # Also covers the re-run caused by this workflow's own push: the datasets
@@ -247,7 +272,7 @@ jobs:
         PUSH_TOKEN: ${{ steps.push_token.outputs.token || secrets.GITHUB_TOKEN }}
       run: |
         cd "${GITHUB_WORKSPACE}"
-        uv run --no-sync python scripts/process_dataset.py \
+        ./pipeline/.venv/bin/python ./pipeline/scripts/process_dataset.py \
           --input_file=changed_data_files.txt \
           --update \
           --cleanup \


### PR DESCRIPTION
## Summary

`process_submission` checked out the pull request and ran `scripts/process_dataset.py` out of it. On a fork that file is contributor-controlled — and so is `uv.lock`, which `uv sync --locked` resolved from the same checkout, so a submission could supply both the code and the packages it ran against. `check_file_types` rejects a fork submission touching anything but dataset files, but that is a policy check standing in front of code execution rather than a boundary.

Stacked on #269, which is stacked on #267.

## Changes

- Check the base branch out into `pipeline/` and run that copy: its `uv.lock`, its `process_dataset.py`, its interpreter. Datasets still come from the pull request; only the code that processes them does not.
- Call the interpreter directly instead of via `uv run`, which resolves the project from the working directory and would have found the pull request's `pyproject.toml` again.
- Reword the `needs: check_file_types` comment. That ordering still gives a fork a clear error rather than a confusing pipeline failure, but it is no longer what stands between a fork and code execution.

## Testing

- Confirmed the venv interpreter runs the script from an unrelated working directory, so the split cwd works and imports resolve from `pipeline/.venv`.
- Confirmed in a scratch repository that an untracked `pipeline/` is invisible to both `git diff --name-status <base>` and `git commit -a`: a staged submission at the root was the only path in the diff and the only file in the resulting commit.
- Workflow YAML parses and the step wiring was read back from the parsed document; pre-commit hooks pass; 50 tests pass.

## Notes

`pipeline/` is nested inside the workspace on purpose: `process_dataset.py` must run with the pull request's tree as its cwd, since it shells out to `git show`, `git diff`, `git mv`, and `git rm` against it.

A pull request that changes both the pipeline and dataset files is now processed by the base's pipeline rather than its own. That is the intended reading of "submissions shouldn't be mixed with code changes" — a submission is not the place to test a pipeline change. I did **not** add a check that rejects such a pull request outright, since that is a new failure mode for maintainer pull requests; easy to add if you want it enforced rather than just handled.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The workflow now obtains submission-processing code, dependencies, and its Python interpreter from a separate checkout of the pull request’s base SHA while continuing to process datasets in the pull-request working tree.
- Adds a nested `pipeline/` checkout at the base commit.
- Synchronizes the pipeline-only dependency group from the base branch’s lockfile.
- Invokes the trusted virtual environment directly for validation and updates.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/submission.yml | Separates contributor-controlled datasets from the base-branch pipeline code and environment; no eligible blocking follow-up issue was established. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  PR[Pull-request checkout] -->|dataset files and Git working tree| PROC[Base-branch process_dataset.py]
  BASE[Base SHA checkout in pipeline/] -->|script and uv.lock| PROC
  VENV[pipeline/.venv Python] --> PROC
  PROC -->|validate, update, and clean up| PR
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/ret..."](https://github.com/open-reaction-database/ord-data/commit/5c9a9c6ceda315d1e0b662492eb9eac0eb96d179) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49417266)</sub>

<!-- /greptile_comment -->