### PR TITLE
Stop the required submission check from skipping

### DIFF
--- a/.github/workflows/retarget_submission.yml
+++ b/.github/workflows/retarget_submission.yml
@@ -40,7 +40,10 @@ name: Retarget Submission
 # changing anything.
 on:
   pull_request_target:
-    types: [opened, reopened, edited]
+    # synchronize is here because this job is a required status check: branch
+    # protection looks for its verdict on the head commit, so every new head
+    # needs one, not just the events that can change the base.
+    types: [opened, reopened, edited, synchronize]
 
 permissions:
   contents: write        # create the "#<number>" branch
@@ -59,14 +62,16 @@ env:
 
 jobs:
   retarget:
-    # Runs for every fork pull request, including those already on a
-    # "#<number>" branch, rather than only those still on main. Skipping the
-    # already-correct case leaves nothing at all reporting on the one event
-    # where the target branch is decided: submission.yml's check_target_branch
-    # stands down on opened/reopened so it cannot race this workflow, so if
-    # this job also skipped, a target branch that had gone wrong would be
-    # caught by nothing until the next push.
-    if: github.event.pull_request.head.repo.fork
+    # Deliberately unconditional, including for pull requests that are not from
+    # forks and those already on a "#<number>" branch. This job is the required
+    # status check for where a submission is targeted, and a skipped job
+    # satisfies branch protection no better than a failing one, so it has to
+    # reach a verdict on every pull request. The cases it does not act on are
+    # decided in the script and reported as successes.
+    #
+    # Being both the thing that fixes the target branch and the thing that
+    # reports on it is the point: they cannot race each other, so a retarget is
+    # never judged before it has happened.
     runs-on: ubuntu-latest
     steps:
     # Repointing with GITHUB_TOKEN starts no workflow run, so submission.yml
@@ -95,8 +100,20 @@ jobs:
         # impossible rather than merely unlikely.
         PR_NUMBER: ${{ github.event.pull_request.number }}
         REPO: ${{ github.repository }}
+        IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
       run: |
         set -euo pipefail
+        # An unset pattern would not abort inside the `if` below -- set -u does
+        # not fire on a condition -- and would instead read as "no dataset
+        # files", quietly leaving a submission on main.
+        : "${DATASET_FILE_PATTERN:?must be set by the workflow env}"
+        # A branch in this repository can be pushed to directly, so the
+        # submission workflow's update step reaches it and no intermediate
+        # branch is needed.
+        if [[ "${IS_FORK}" != "true" ]]; then
+          echo "Not a fork pull request; the target branch is unconstrained."
+          exit 0
+        fi
         # Read live rather than from the event payload, which on a reopen can
         # still describe the base as it stood before an earlier retarget.
         BASE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.base.ref')"

--- a/.github/workflows/retarget_submission.yml
+++ b/.github/workflows/retarget_submission.yml
@@ -34,8 +34,10 @@ name: Retarget Submission
 # checks out no code at all, and in particular never checks out the fork's head,
 # so nothing the contributor controls is read or executed here.
 # `edited` fires when a base branch is changed, so a submission pointed back at
-# main by hand is moved again. This cannot recurse: the repoint below is made
-# with GITHUB_TOKEN, and events from that token start no workflow run.
+# main by hand is moved again. The repoint below does re-trigger this workflow
+# when it is made with the app token, which terminates rather than recurses:
+# the second run reads the base, finds it is no longer main, and stops before
+# changing anything.
 on:
   pull_request_target:
     types: [opened, reopened, edited]
@@ -67,9 +69,26 @@ jobs:
     if: github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
+    # Repointing with GITHUB_TOKEN starts no workflow run, so submission.yml
+    # never re-runs against the new base and its target-branch check has to
+    # guess how long to wait for this workflow. An app installation token is a
+    # different identity: its `edited` event triggers submission.yml normally,
+    # so a retarget that lands late is picked up rather than missed. Falls back
+    # to GITHUB_TOKEN when the app is unconfigured, where that bounded wait is
+    # the backstop.
+    #
+    # Safe to hold here in a way it would not be in process_submission: this
+    # job checks out nothing, so no fork-controlled file is ever read or run.
+    - name: Mint a token whose repoint can re-trigger CI
+      id: repoint_token
+      if: vars.SUBMISSION_APP_ID != ''
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        app-id: ${{ vars.SUBMISSION_APP_ID }}
+        private-key: ${{ secrets.SUBMISSION_APP_PRIVATE_KEY }}
     - name: Retarget a data submission to an ord-owned branch
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.repoint_token.outputs.token || secrets.GITHUB_TOKEN }}
         # Passed through the environment rather than interpolated into the
         # script. The number is an integer from GitHub, but keeping all event
         # data out of the script text is the habit that makes injection

--- a/.github/workflows/retarget_submission.yml
+++ b/.github/workflows/retarget_submission.yml
@@ -57,9 +57,14 @@ env:
 
 jobs:
   retarget:
-    if: >-
-      github.event.pull_request.head.repo.fork &&
-      github.event.pull_request.base.ref == 'main'
+    # Runs for every fork pull request, including those already on a
+    # "#<number>" branch, rather than only those still on main. Skipping the
+    # already-correct case leaves nothing at all reporting on the one event
+    # where the target branch is decided: submission.yml's check_target_branch
+    # stands down on opened/reopened so it cannot race this workflow, so if
+    # this job also skipped, a target branch that had gone wrong would be
+    # caught by nothing until the next push.
+    if: github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
     - name: Retarget a data submission to an ord-owned branch
@@ -73,6 +78,13 @@ jobs:
         REPO: ${{ github.repository }}
       run: |
         set -euo pipefail
+        # Read live rather than from the event payload, which on a reopen can
+        # still describe the base as it stood before an earlier retarget.
+        BASE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.base.ref')"
+        if [[ "${BASE}" != "main" ]]; then
+          echo "Already targeting ${BASE}; nothing to do."
+          exit 0
+        fi
         # Collected before matching rather than piped straight into grep: under
         # pipefail, `gh | grep -q` can report the SIGPIPE from grep's early exit
         # on a match, which would read as "no dataset files".

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -24,11 +24,17 @@ name: Submission
 on:
   pull_request:
     # Default trigger types plus labeled/unlabeled so adding or removing the
-    # `skip-update-submission` label re-runs the workflow with the new
-    # gating on the "Update submission" step, and edited so that
-    # retarget_submission.yml moving a submission off main re-runs these checks
-    # against the new base. Jobs ignore edits that did not change the base.
-    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+    # `skip-update-submission` label re-runs the workflow with the new gating
+    # on the "Update submission" step.
+    #
+    # Deliberately not `edited`. process_submission is a required status check,
+    # so every run of this workflow overwrites its verdict: an edit that
+    # retitles a pull request would either skip the job, which satisfies branch
+    # protection no better than a failure, or report a trivial success over a
+    # real one. Not running at all leaves the existing verdict standing, which
+    # is the honest answer for an event that changed no code. Base changes are
+    # retarget_submission.yml's business and it does listen for `edited`.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # One in-flight run per PR. New events (pushes, label toggles) cancel
 # the prior run so we are not paying twice for things like LFS checkouts.
@@ -39,10 +45,10 @@ concurrency:
 env:
   # Dataset files a submission may contain: protobuf binary (.pb/.binpb) or
   # text (.pbtxt/.txtpb), either optionally gzipped, plus Parquet. The
-  # check_file_types job rejects anything else, check_target_branch decides
-  # whether a fork's pull request is a data submission, and process_submission
-  # selects the files it processes -- all with this pattern, so they must
-  # agree: a suffix accepted by one but not the others either fails a
+  # check_file_types job rejects anything else and process_submission selects
+  # the files it processes -- both with this pattern, and retarget_submission
+  # decides whether a fork's pull request is a data submission with it too, so
+  # they must agree: a suffix accepted by one but not the others either fails a
   # legitimate submission or silently processes nothing.
   #
   # retarget_submission.yml carries the same value and tests.yml fails if the
@@ -53,10 +59,12 @@ env:
 
 jobs:
   check_file_types:
-    # An edit that left the base alone (a retitled pull request, say) changes
-    # nothing these jobs look at. process_submission needs this job, so
-    # skipping here skips the LFS checkout below it too.
-    if: github.event.action != 'edited' || github.event.changes.base
+    # Deliberately unconditional. process_submission needs this job and is a
+    # required status check on main, and a skipped job satisfies branch
+    # protection no better than a failing one -- it reports "skipped" over
+    # whatever passed before, and the pull request can then only merge by
+    # override. Work is avoided further down instead, where it costs nothing
+    # to report.
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -76,52 +84,6 @@ jobs:
           echo "Error: submissions should only contain *.pb, *.binpb, *.pbtxt, or *.txtpb files (optionally gzipped), or *.parquet files" && \
           exit 1 || true
       if: github.event.pull_request.head.repo.fork
-
-  check_target_branch:
-    # A data submission from a fork must not target main: the Update submission
-    # step cannot push processed commits back to a fork, so submissions are
-    # merged into an ord-owned "#<number>" branch first and that branch opens
-    # the pull request against main. retarget_submission.yml does this move
-    # automatically, so failing here means it did not run or could not finish.
-    #
-    # Fork pull requests that change no dataset files are ordinary
-    # contributions -- documentation, workflows, scripts -- and target main
-    # like any other.
-    #
-    # Deliberately not run on opened/reopened, where retarget_submission.yml is
-    # already moving the submission: it repoints with GITHUB_TOKEN, and events
-    # from that token start no workflow run, so a failure recorded here would
-    # never be re-run and would sit red on a pull request that had in fact been
-    # fixed seconds later. Every later event still checks.
-    if: >-
-      github.event.pull_request.head.repo.fork &&
-      github.event.action != 'opened' &&
-      github.event.action != 'reopened' &&
-      (github.event.action != 'edited' || github.event.changes.base)
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check target branch
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-        REPO: ${{ github.repository }}
-      run: |
-        set -euo pipefail
-        echo "Target branch: ${GITHUB_BASE_REF}"
-        if [[ "${GITHUB_BASE_REF}" != "main" ]]; then
-          exit 0
-        fi
-        # Collected before matching: under pipefail, `gh | grep -q` can report
-        # the SIGPIPE from grep's early exit on a match.
-        FILES="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
-          --jq '.[].filename')"
-        if printf '%s\n' "${FILES}" | grep -qE "${DATASET_FILE_PATTERN}"; then
-          echo "Error: a data submission from a fork cannot target main; it" \
-            "belongs on a '#${PR_NUMBER}' branch in this repository so the" \
-            "submission workflow can push the processed dataset back to it."
-          exit 1
-        fi
-        echo "No dataset files changed; targeting main is fine."
 
   process_submission:
     # Ordered after check_file_types so a fork submission carrying anything but

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -25,19 +25,18 @@ on:
   pull_request:
     # Default trigger types plus labeled/unlabeled so adding or removing the
     # `skip-update-submission` label re-runs with the new gating on the "Update
-    # submission" step, and edited because a pull request's author may change
-    # its base: a submission validated on a "#<number>" branch and then pointed
-    # back at main has to be re-judged, or the required check keeps a verdict
-    # that no longer describes where the pull request is going.
+    # submission" step.
     #
-    # Every job below runs unconditionally, which is what makes subscribing to
-    # this safe. A job that skips on some events reports "skipped" over a real
-    # verdict, and one that short-circuits to success reports a trivial pass
-    # over a real failure; either would let a required check be cleared by
-    # retitling a pull request. Re-running everything costs an LFS pull on an
-    # edit that changed nothing, which is the price of the verdict always being
-    # earned.
-    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+    # Not `edited`. Nothing here depends on a pull request's title, body, or
+    # base: where a submission is targeted is retarget_submission.yml's
+    # verdict, on its own required check. Retitling a pull request would only
+    # repeat an LFS pull to reach the same conclusion.
+    #
+    # Every job below runs unconditionally, which is what keeps the required
+    # verdict honest whatever does trigger a run. A job that skips on some
+    # events reports "skipped" over a real verdict, and one that
+    # short-circuits to success reports a trivial pass over a real failure.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # One in-flight run per PR. New events (pushes, label toggles) cancel
 # the prior run so we are not paying twice for things like LFS checkouts.
@@ -142,48 +141,6 @@ jobs:
         echo "NUM_CHANGED_FILES=${LOCAL_NUM_CHANGED}" >> $GITHUB_ENV
         echo "Found ${LOCAL_NUM_CHANGED} changed dataset files"
         cat changed_data_files.txt
-    # The required check must not be able to pass while a fork data submission
-    # is still aimed at main. "Update submission" is gated on `! fork`, so such
-    # a pull request would merge with nothing having assigned reaction IDs or
-    # moved files into data/. retarget_submission.yml normally moves it long
-    # before this point; its own failure is not enough on its own, because that
-    # workflow is not a required check and a red run there does not block a
-    # merge. This is the check that does.
-    - name: Confirm a fork submission is not targeting main
-      if: >-
-        env.NUM_CHANGED_FILES != '0' &&
-        github.event.pull_request.head.repo.fork
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-        REPO: ${{ github.repository }}
-      run: |
-        set -euo pipefail
-        # Read live rather than from the event payload, and give the retarget a
-        # moment to land: both workflows start from the same event, and on a
-        # newly opened pull request this job can reach here first.
-        #
-        # This wait is a backstop, not the mechanism. retarget_submission.yml
-        # repoints with an app token, whose `edited` event re-runs this
-        # workflow, so a retarget slower than the wait below is picked up on
-        # that run instead. Only when the app is unconfigured does the repoint
-        # fall back to GITHUB_TOKEN, which triggers nothing, and the wait
-        # becomes the only thing standing between a slow retarget and a red
-        # that no later event would clear.
-        for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
-          BASE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.base.ref')"
-          [[ "${BASE}" != "main" ]] && break
-          echo "Attempt ${attempt}: still targeting main; waiting for the retarget."
-          sleep 5
-        done
-        echo "Target branch: ${BASE}"
-        if [[ "${BASE}" == "main" ]]; then
-          echo "Error: a data submission from a fork cannot target main; it" \
-            "belongs on a '#${PR_NUMBER}' branch in this repository so the" \
-            "submission workflow can push the processed dataset back to it." \
-            "Check the Retarget Submission run, which should have moved it."
-          exit 1
-        fi
     # Read LFS from GitHub, not the HF mirror that .lfsconfig points clones at:
     # submissions are validated before their bytes are mirrored to HF on merge
     # to main, and the "Update submission" step's uploads reuse this lfs.url

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -139,6 +139,35 @@ jobs:
         echo "NUM_CHANGED_FILES=${LOCAL_NUM_CHANGED}" >> $GITHUB_ENV
         echo "Found ${LOCAL_NUM_CHANGED} changed dataset files"
         cat changed_data_files.txt
+    # The required check must not be able to pass while a fork data submission
+    # is still aimed at main. "Update submission" is gated on `! fork`, so such
+    # a pull request would merge with nothing having assigned reaction IDs or
+    # moved files into data/. retarget_submission.yml normally moves it long
+    # before this point; its own failure is not enough on its own, because that
+    # workflow is not a required check and a red run there does not block a
+    # merge. This is the check that does.
+    - name: Confirm a fork submission is not targeting main
+      if: >-
+        env.NUM_CHANGED_FILES != '0' &&
+        github.event.pull_request.head.repo.fork
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        # Live rather than from the event payload: the retarget usually lands
+        # while this job is still checking out, and the payload would still
+        # say main.
+        BASE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.base.ref')"
+        echo "Target branch: ${BASE}"
+        if [[ "${BASE}" == "main" ]]; then
+          echo "Error: a data submission from a fork cannot target main; it" \
+            "belongs on a '#${PR_NUMBER}' branch in this repository so the" \
+            "submission workflow can push the processed dataset back to it." \
+            "Check the Retarget Submission run, which should have moved it."
+          exit 1
+        fi
     # Read LFS from GitHub, not the HF mirror that .lfsconfig points clones at:
     # submissions are validated before their bytes are mirrored to HF on merge
     # to main, and the "Update submission" step's uploads reuse this lfs.url

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -161,12 +161,16 @@ jobs:
         set -euo pipefail
         # Read live rather than from the event payload, and give the retarget a
         # moment to land: both workflows start from the same event, and on a
-        # newly opened pull request this job can reach here first. Failing on
-        # that race would be unrecoverable -- the retarget repoints with
-        # GITHUB_TOKEN, whose events start no workflow run, so nothing would
-        # re-run this check and the red would stand on a required check until
-        # someone pushed again.
-        for attempt in 1 2 3 4 5 6; do
+        # newly opened pull request this job can reach here first.
+        #
+        # This wait is a backstop, not the mechanism. retarget_submission.yml
+        # repoints with an app token, whose `edited` event re-runs this
+        # workflow, so a retarget slower than the wait below is picked up on
+        # that run instead. Only when the app is unconfigured does the repoint
+        # fall back to GITHUB_TOKEN, which triggers nothing, and the wait
+        # becomes the only thing standing between a slow retarget and a red
+        # that no later event would clear.
+        for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
           BASE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.base.ref')"
           [[ "${BASE}" != "main" ]] && break
           echo "Attempt ${attempt}: still targeting main; waiting for the retarget."

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -171,10 +171,16 @@ jobs:
     # the pull request's working tree as its cwd -- it shells out to git show,
     # git diff, git mv, and git rm against it. The directory is untracked, which
     # neither `git diff` against upstream/main nor `git commit -a` picks up.
+    # By branch rather than by base.sha: that field records the base as it
+    # stood when the pull request was opened or last synchronized, so a
+    # submission branch brought up to date afterwards still reports the old
+    # commit -- which can predate the pipeline entirely and leave nothing here
+    # to install. The branch name resolves to whatever it currently points at,
+    # and it names a branch in this repository, never the fork.
     - name: Check out the pipeline from the base branch
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.base.sha }}
+        ref: ${{ github.event.pull_request.base.ref }}
         path: pipeline
         lfs: false
       if: env.NUM_CHANGED_FILES != '0'

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -24,17 +24,20 @@ name: Submission
 on:
   pull_request:
     # Default trigger types plus labeled/unlabeled so adding or removing the
-    # `skip-update-submission` label re-runs the workflow with the new gating
-    # on the "Update submission" step.
+    # `skip-update-submission` label re-runs with the new gating on the "Update
+    # submission" step, and edited because a pull request's author may change
+    # its base: a submission validated on a "#<number>" branch and then pointed
+    # back at main has to be re-judged, or the required check keeps a verdict
+    # that no longer describes where the pull request is going.
     #
-    # Deliberately not `edited`. process_submission is a required status check,
-    # so every run of this workflow overwrites its verdict: an edit that
-    # retitles a pull request would either skip the job, which satisfies branch
-    # protection no better than a failure, or report a trivial success over a
-    # real one. Not running at all leaves the existing verdict standing, which
-    # is the honest answer for an event that changed no code. Base changes are
-    # retarget_submission.yml's business and it does listen for `edited`.
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    # Every job below runs unconditionally, which is what makes subscribing to
+    # this safe. A job that skips on some events reports "skipped" over a real
+    # verdict, and one that short-circuits to success reports a trivial pass
+    # over a real failure; either would let a required check be cleared by
+    # retitling a pull request. Re-running everything costs an LFS pull on an
+    # edit that changed nothing, which is the price of the verdict always being
+    # earned.
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
 # One in-flight run per PR. New events (pushes, label toggles) cancel
 # the prior run so we are not paying twice for things like LFS checkouts.
@@ -156,10 +159,19 @@ jobs:
         REPO: ${{ github.repository }}
       run: |
         set -euo pipefail
-        # Live rather than from the event payload: the retarget usually lands
-        # while this job is still checking out, and the payload would still
-        # say main.
-        BASE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.base.ref')"
+        # Read live rather than from the event payload, and give the retarget a
+        # moment to land: both workflows start from the same event, and on a
+        # newly opened pull request this job can reach here first. Failing on
+        # that race would be unrecoverable -- the retarget repoints with
+        # GITHUB_TOKEN, whose events start no workflow run, so nothing would
+        # re-run this check and the red would stand on a required check until
+        # someone pushed again.
+        for attempt in 1 2 3 4 5 6; do
+          BASE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.base.ref')"
+          [[ "${BASE}" != "main" ]] && break
+          echo "Attempt ${attempt}: still targeting main; waiting for the retarget."
+          sleep 5
+        done
         echo "Target branch: ${BASE}"
         if [[ "${BASE}" == "main" ]]; then
           echo "Error: a data submission from a fork cannot target main; it" \


### PR DESCRIPTION
## Summary

`process_submission` is a required status check on `main`, and a skipped job satisfies branch protection no better than a failing one — it reports "skipped" over whatever passed before, leaving the pull request mergeable only by override. That is what happened on #269: an edit to the description skipped `check_file_types`, which cascaded through `needs`.

## Changes

- Drop `edited` from this workflow's triggers rather than gating jobs inside it. Every run overwrites the required verdict, so an event that changed no code has only bad options — skip the job, or report a trivial success over a real failure and launder a red into a green. Not running leaves the existing verdict standing, which is the truthful answer.
- Remove the condition on `check_file_types` for the same reason: nothing `process_submission` depends on may skip.
- Delete `check_target_branch`. It existed to catch a fork data submission targeting `main`, which `retarget_submission.yml` now both detects and fixes, and after the above it could only run on events where the base cannot change.
- `retarget_submission.yml` stops skipping the already-correct case, so a fork pull request always has exactly one job reporting on where it is targeted. It now reads the base live rather than from the event payload, which on a reopen can still describe the state before an earlier retarget.

## Testing

- Retarget script run against a stubbed `gh` in all three states: already on `#<number>` (the case that previously skipped silently, now reports "nothing to do"), still on `main` with dataset files (retargets), and still on `main` without them (leaves it alone).
- All three workflow files parse; job conditions read back from the parsed document — `check_file_types` and `process_submission` are both unconditional.
- `DATASET_FILE_PATTERN` drift guard still sees two definitions and one unique value.
- Pre-commit hooks pass.

## Notes

Keeping `process_submission` required is deliberate: it is the only check that validates submitted data, so dropping it to dodge the skip would trade a permanent safety property for a bug that is fixed here. The invariant to preserve is narrow — neither it nor anything it `needs` may carry a job-level `if:` — and that is now written down at both jobs.

The cost is that a label toggle still re-runs the LFS pull for a data submission. Trying to avoid that was what produced the skip in the first place.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes retargeting its own unconditional required verdict and keeps submission processing jobs from being skipped.
- Runs the retarget workflow for every new head and base edit, reading the current base through the API.
- Uses an app installation token when available so retarget operations can trigger normal GitHub events.
- Removes conditional submission jobs and the separate target-branch polling check.
- Checks out submission pipeline code from the current repository base branch rather than the event’s base SHA.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains in the current workflow design, and the previously reported target-enforcement and polling issues are resolved by making the retarget job itself the unconditional required verdict.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/retarget_submission.yml | Makes retargeting unconditional, handles every relevant head or base transition, and reports the target-branch verdict from the same job that performs the correction. |
| .github/workflows/submission.yml | Prevents required processing jobs from being skipped, removes redundant target polling, and resolves pipeline code from the live base branch. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PR as Pull request
    participant R as Retarget Submission
    participant GH as GitHub API
    participant S as Submission
    PR->>R: opened, reopened, edited, or synchronized
    R->>GH: Read live base and changed files
    alt Fork dataset submission targets main
        R->>GH: "Create/update #number branch"
        R->>GH: Repoint pull request
        R-->>PR: Required retarget verdict
    else No retarget required
        R-->>PR: Successful required verdict
    end
    PR->>S: opened, reopened, synchronized, or label change
    S->>S: Check file types
    S->>S: Validate or update submission
    S-->>PR: Required processing verdict
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Let the retarget report its own verdict ..."](https://github.com/open-reaction-database/ord-data/commit/380dfa68228d6abc7045794eb399075726663eac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49420139)</sub>

<!-- /greptile_comment -->