### PR TITLE
Pin the remaining actions to SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Actions are pinned to commit SHAs, which is what makes a third party unable
+# to change what runs here by moving a tag. The cost is that a pin is invisible
+# when it goes stale, including for security fixes, so something has to offer
+# the updates: that is this file's job.
+#
+# Updates are grouped so each ecosystem produces one pull request rather than
+# one per dependency. Monthly suits a repository whose CI changes rarely, and
+# every update still passes the same required checks as any other change.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "Bump"
+
+  # Covers pyproject.toml and uv.lock together, so a bump cannot land in one
+  # without the other and leave `uv sync --locked` failing in CI.
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      python:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "Bump"

--- a/.github/workflows/huggingface_mirror.yml
+++ b/.github/workflows/huggingface_mirror.yml
@@ -49,7 +49,7 @@ jobs:
   mirror:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0
         lfs: false

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -69,7 +69,7 @@ jobs:
     # to report.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Add upstream for comparisons to HEAD
       run: |
         cd "${GITHUB_WORKSPACE}"
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout ord-data
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         lfs: false
@@ -180,7 +180,7 @@ jobs:
     # to install. The branch name resolves to whatever it currently points at,
     # and it names a branch in this repository, never the fork.
     - name: Check out the pipeline from the base branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         ref: ${{ github.event.pull_request.base.ref }}
         path: pipeline

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout ord-data
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       # The tests exercise pure functions and build their own fixtures under
       # tmp_path, so no dataset objects are needed.
       with:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -54,7 +54,7 @@ jobs:
         ]
     steps:
     - name: Checkout ord-data
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         lfs: false
     # .lfsconfig redirects clone/fetch LFS reads to the Hugging Face mirror to
@@ -74,12 +74,12 @@ jobs:
         git config lfs.url "https://github.com/${GITHUB_REPOSITORY}.git/info/lfs"
         git lfs pull --include="${FILTER}/*.pb*"
     - name: Checkout ord-schema
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: Open-Reaction-Database/ord-schema
         ref: ${{ env.ORD_SCHEMA_TAG }}
         path: ord-schema
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.11'
     - name: Install ord_schema
@@ -118,7 +118,7 @@ jobs:
             lfs_exclude: 'data/*/ord_dataset-1158e351757f315b93cbcbe7bc55f38e.parquet'
     steps:
     - name: Checkout ord-data
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         lfs: false
     # See validate_pb: read this shard's LFS objects from GitHub rather than the
@@ -135,12 +135,12 @@ jobs:
           git lfs pull --include="${LFS_INCLUDE}"
         fi
     - name: Checkout ord-schema
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: Open-Reaction-Database/ord-schema
         ref: ${{ env.ORD_SCHEMA_TAG }}
         path: ord-schema
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.11'
     - name: Install ord_schema


### PR DESCRIPTION
## Summary

`actions/checkout` and `actions/setup-python` were still referenced by tag, so whoever controls those tags controls what runs in workflows holding a `GITHUB_TOKEN` and, in `submission.yml`, an app installation token. Every action in the repository is now a commit SHA.

Supersedes #264, whose branch predated the submission workflow being rewritten and still carried the pipeline scripts that stayed in ord-schema.

## Changes

- Pin 11 uses across four workflows: `actions/checkout@11d5960a` (v4) and `actions/setup-python@a26af69b` (v5). `setup-uv` and `create-github-app-token` were already pinned by earlier work.
- Add `.github/dependabot.yml`. Pinning trades one risk for another — a stale pin is invisible, security fixes included — so something has to offer the updates.

## Testing

- Verified both SHAs resolve to the tags they claim, against the GitHub API rather than by trusting the value copied in.
- No unpinned `uses:` remain: `grep` for `@v<n>` across `.github/workflows/` returns nothing.
- Dependabot config and all five workflows parse as YAML; pre-commit hooks pass.

## Notes

Updates are grouped so each ecosystem opens one pull request rather than one per dependency, and monthly rather than weekly, since CI here changes rarely. Every Dependabot pull request still passes the same required checks as any other change.

The `uv` ecosystem covers `pyproject.toml` and `uv.lock` together, so a bump cannot land in one without the other and leave `uv sync --locked` failing in CI.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces mutable action tags with immutable commit SHAs and adds monthly, grouped Dependabot updates for GitHub Actions and uv dependencies.
- Pins every changed `actions/checkout` reference to the same v4 commit.
- Pins `actions/setup-python` references to a v5 commit.
- Configures grouped monthly updates for workflow actions and the root uv project.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional or security defects identified in the changed configuration.

The immutable action references preserve the prior action versions and inputs, while the Dependabot configuration covers the repository's root uv manifests and all GitHub Actions workflows.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds valid root-level monthly update groups for GitHub Actions and the repository's `pyproject.toml`/`uv.lock` pair. |
| .github/workflows/huggingface_mirror.yml | Replaces the mutable checkout v4 tag with an immutable commit pin without changing action inputs. |
| .github/workflows/submission.yml | Pins all three checkout uses while preserving their existing refs, paths, and submission behavior. |
| .github/workflows/tests.yml | Pins the test workflow's checkout action without changing its configuration. |
| .github/workflows/validation.yml | Pins checkout and setup-python uses while preserving validation matrix behavior and action inputs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Pin the remaining actions to SHAs and ad..."](https://github.com/open-reaction-database/ord-data/commit/d6743c2302e4a6f6060d4bdaa5b4f1e7fe4387a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49422757)</sub>

<!-- /greptile_comment -->