### PR TITLE
Report every invalid file in a submission, not just the first

### DIFF
--- a/scripts/process_dataset.py
+++ b/scripts/process_dataset.py
@@ -330,6 +330,10 @@ def run(
         return set(), set(), set()  # Nothing to do.
     # NOTE(kearnes): Process one dataset at a time to avoid OOM errors.
     change_stats = {}
+    # Collected rather than raised on the spot so that a submission of several
+    # files reports every invalid one. Raising at the first would make a
+    # contributor fix, push, and wait once per bad file to discover the rest.
+    validation_errors: list[str] = []
     for file_status in inputs:
         dataset: dataset_pb2.Dataset | parquet.DatasetView | None
         if file_status.status == "D":
@@ -352,17 +356,25 @@ def run(
         datasets_checked: dict[str, dataset_pb2.Dataset | parquet.DatasetView] = (
             {file_status.filename: dataset} if dataset is not None else {}
         )
+        is_valid = True
         if not args.no_validate and dataset is not None:
-            # Note: this does not check if IDs are malformed.
-            validations.validate_datasets(datasets_checked, args.write_errors)
-            # Check reaction sizes.
-            for reaction in dataset.reactions:
-                reaction_size = sys.getsizeof(reaction.SerializeToString()) / 1e6
-                if reaction_size > args.max_size:
-                    raise ValueError(
-                        f"Reaction is larger than --max_size "
-                        f"({reaction_size} vs {args.max_size})"
-                    )
+            try:
+                # Note: this does not check if IDs are malformed.
+                validations.validate_datasets(datasets_checked, args.write_errors)
+            except validations.ValidationError as error:
+                validation_errors.append(f"{file_status.filename}: {error}")
+                is_valid = False
+            else:
+                # Check reaction sizes. Left to raise where it stands: it is a
+                # hard limit rather than a data defect, and one oversized
+                # reaction says nothing useful about the remaining files.
+                for reaction in dataset.reactions:
+                    reaction_size = sys.getsizeof(reaction.SerializeToString()) / 1e6
+                    if reaction_size > args.max_size:
+                        raise ValueError(
+                            f"Reaction is larger than --max_size "
+                            f"({reaction_size} vs {args.max_size})"
+                        )
         if args.base:
             added, removed, changed = get_change_stats(
                 datasets, [file_status], base=args.base
@@ -374,7 +386,7 @@ def run(
                 len(removed),
                 len(changed),
             )
-        if args.update and dataset is not None:
+        if args.update and dataset is not None and is_valid:
             _run_updates(
                 datasets_checked,
                 root=args.root,
@@ -382,6 +394,11 @@ def run(
                 write_errors=args.write_errors,
                 cleanup_files=args.cleanup,
             )
+    if validation_errors:
+        raise validations.ValidationError(
+            f"validation encountered errors in {len(validation_errors)} of "
+            f"{len(inputs)} files:\n" + "\n".join(validation_errors)
+        )
     if change_stats:
         total_added, total_removed, total_changed = set(), set(), set()
         comment = [

--- a/scripts/process_dataset_test.py
+++ b/scripts/process_dataset_test.py
@@ -92,6 +92,26 @@ class TestProcessDataset:
         with pathlib.Path(error_filename).open() as f:
             assert f.readlines() == expected_output
 
+    def test_every_invalid_input_is_reported(self, setup, tmp_path):
+        # Stopping at the first bad file makes a contributor fix, push, and
+        # wait once per file to discover the rest; ord-data#265 arrived with
+        # two datasets and only the first was ever validated.
+        _, dataset2_filename = setup
+        second_bad = (tmp_path / "dataset3.pbtxt").as_posix()
+        message_helpers.save_message(
+            dataset_pb2.Dataset(
+                name="test3", description="test3", reactions=[reaction_pb2.Reaction()]
+            ),
+            second_bad,
+        )
+        argv = ["--input_pattern", (tmp_path / "*.pb*").as_posix()]
+        with pytest.raises(validations.ValidationError) as excinfo:
+            process_dataset.main(process_dataset.parse_args(argv))
+        message = str(excinfo.value)
+        assert pathlib.Path(dataset2_filename).name in message
+        assert pathlib.Path(second_bad).name in message
+        assert "in 2 of" in message
+
     def test_main_with_updates(self, setup):
         dataset1_filename, _ = setup
         dirname = str(pathlib.Path(dataset1_filename).parent)


### PR DESCRIPTION
## Summary

`validate_datasets` raised inside the per-file loop, so a submission of several datasets was judged on whichever sorted first. #265 arrived with two files and only ever saw one validated: 48 errors in `Dreher_exp1_revised.binpb`, and nothing said about `Dreher_exp2_revised.binpb`, which was never read. A contributor cannot tell that from the output and reasonably reads silence as a pass — so the real cost is a fix-push-wait cycle per bad file.

## Changes

- Collect validation failures across all inputs and raise once at the end, naming each file and how many of the inputs failed.
- Skip `--update` for a file that failed validation, so nothing is rewritten on the strength of a dataset that did not validate.

## Testing

- New `test_every_invalid_input_is_reported` builds two invalid datasets and asserts both filenames and the failure count appear in the message. Reverting only the `run()` change fails it, so it pins the behavior rather than restating it.
- Full suite passes: 51 tests, up from 50. Pre-commit hooks pass.

## Notes

The reaction-size check still raises where it stands. It is a hard limit rather than a data defect, and one oversized reaction says nothing useful about the remaining files.

Worth knowing for review: this changes what a failing run reports, not whether it fails. A submission with any invalid file still exits non-zero and still blocks `process_submission`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes dataset processing to collect validation failures across all inputs while preventing updates to each invalid dataset.
- Reports all invalid input filenames in one final validation error.
- Skips reaction-size checks and updates for datasets that fail ordinary validation.
- Adds a regression test covering multiple invalid inputs.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains within the eligible follow-up review scope.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/process_dataset.py | Aggregates per-file validation failures, skips updates for invalid datasets, and raises once after processing all inputs. |
| scripts/process_dataset_test.py | Adds regression coverage verifying that multiple invalid filenames and the failed-file count appear in the aggregate error. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Load next dataset] --> B{Validation enabled?}
  B -- No --> E[Process optional update]
  B -- Yes --> C{Dataset valid?}
  C -- Yes --> D[Check reaction sizes]
  D --> E
  C -- No --> F[Record validation error]
  F --> G[Skip update]
  E --> H{More inputs?}
  G --> H
  H -- Yes --> A
  H -- No --> I{Any validation errors?}
  I -- Yes --> J[Raise aggregate ValidationError]
  I -- No --> K[Return results]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/open-reaction-database/ord-data/commit/7fabedcaa1a274639f8e0d64418fc5c158746000) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49423304)</sub>

<!-- /greptile_comment -->