### PR TITLE
Validate on merge only when the data changed

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -20,16 +20,35 @@ on:
   push:
     branches:
       - main
+    # Every merge used to re-validate the whole corpus: 2.4 GB of Git LFS
+    # across 603 files, pulled from GitHub rather than the Hugging Face mirror
+    # (see the fetch step for why that has to be GitHub). Most merges here
+    # change workflows or scripts and no data at all, so that bandwidth bought
+    # nothing. Validate on a push only when the data, or the thing that
+    # validates it, actually changed.
+    paths:
+      - 'data/**'
+      - '.github/workflows/validation.yml'
   pull_request:
     paths:
       # Runs when this file is modified in a PR.
       - '.github/workflows/validation.yml'
+  schedule:
+    # The per-merge run was also, incidentally, a standing sweep for bit rot
+    # and for corruption arriving by some path other than a dataset commit.
+    # Narrowing the push trigger would drop that, so it moves here: 07:00 UTC
+    # on Mondays, whole corpus, no merge waiting on it.
+    - cron: '0 7 * * 1'
 
 # One in-flight matrix per PR (or per push to main). Subsequent events
 # cancel the prior run so we are not paying twice for the LFS-heavy
 # validate_pb / validate_parquet shards.
+#
+# Keyed on the event as well as the ref: a scheduled run and a push to main
+# share a ref, so without it a merge would cancel the weekly sweep and that
+# week's corpus check would simply not happen.
 concurrency:
-  group: validation-${{ github.event.pull_request.number || github.ref }}
+  group: validation-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary

Every push to `main` re-validated the whole corpus: 2.4 GB of Git LFS across 603 files, read from GitHub rather than the Hugging Face mirror. Most merges here change workflows or scripts and no data at all — all five that landed today did — so that bandwidth bought nothing. This session alone spent roughly 12 GB validating data nobody had touched.

## Changes

- Filter the push trigger on `data/**` and this workflow. Dataset merges still validate; the last five submissions all touched `data/` and are unaffected.
- Add a Monday 07:00 UTC `schedule:`. The per-merge run was also, incidentally, a standing sweep for bit rot and for corruption arriving by some path other than a dataset commit; narrowing the trigger would drop that, so it moves here — same coverage, no merge waiting on it.
- Key the concurrency group on the event name as well as the ref. A scheduled run and a push to `main` share a ref, so without it a merge would cancel the weekly sweep and that week's check would simply not happen.

## Testing

- Checked the filter against real history: all five merges from today (#266, #267, #268, #269, #271) touch zero matching paths and would be skipped, while the five most recent data-bearing merges (`ad4a2e1`, `ddb0d25`, `bfea35a`, `e190a1b`, `f48c1c2`) all touch `data/` and still trigger.
- Workflow parses; triggers, concurrency expression, and both matrix jobs read back from the parsed document.

## Notes

Pointing validation at the Hugging Face mirror was the other way to cut this, and it is wrong: on a push to `main` the mirror job has not run yet, so validation would pass on the previous bytes of exactly the dataset that just changed. That is why the fetch step overrides `.lfsconfig` back to GitHub, and this change leaves that alone.

The sharding was already efficient — each of the nine `validate_pb` jobs pulls only its own slice, so a run costs about one corpus read rather than nine. The waste was in how often a run happened, not in what each one transferred.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR avoids unnecessary full-corpus validation after unrelated pushes while retaining immediate validation for dataset and workflow changes.
- Restricts the `main` push trigger to `data/**` and the validation workflow itself.
- Adds a weekly full-corpus validation schedule for ongoing integrity checks.
- Separates push, pull-request, and scheduled runs in the concurrency key to prevent cross-event cancellation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with dataset changes still validated immediately and scheduled integrity checks protected from push cancellation.

The narrowed path filter covers every repository-local input consumed by the validation jobs, and including the event name in the concurrency group prevents scheduled and push runs from canceling one another.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/validation.yml | The trigger and concurrency changes preserve current validation coverage while avoiding redundant runs; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Validate on merge only when the data cha..."](https://github.com/open-reaction-database/ord-data/commit/5b42073fbbe1ed71d7cb571a3ff455b2dd323689) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49423549)</sub>

<!-- /greptile_comment -->