### PR TITLE
Take a submission's file list from the API, not a diff against main

### DIFF
--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -69,22 +69,33 @@ jobs:
     # to report.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-    - name: Add upstream for comparisons to HEAD
-      run: |
-        cd "${GITHUB_WORKSPACE}"
-        git remote add upstream \
-          "https://github.com/Open-Reaction-Database/${GITHUB_REPOSITORY##*/}.git"
-        echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
-        git fetch --no-tags --prune --depth=1 upstream \
-          +refs/heads/*:refs/remotes/upstream/*
+    # The changed files come from the API rather than a diff against
+    # upstream/main. A submission sits on a "#<number>" branch that drifts
+    # behind main as other work merges, and diffing the pull request against
+    # main counts every one of those merges as a file the submission touched:
+    # a contributor is then told their submission contains workflows and
+    # scripts they never saw. The API answers the question actually being
+    # asked -- what does this pull request change -- however stale its base is.
+    #
+    # A merge base would do too, but the shallow fetch this job used to do has
+    # no shared history to compute one from.
     - name: Check changed files (PR from fork)
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
       run: |
-        cd "${GITHUB_WORKSPACE}"
-        git diff --name-only upstream/main > changed_files.txt
-        grep -vE "${DATASET_FILE_PATTERN}" changed_files.txt && \
-          echo "Error: submissions should only contain *.pb, *.binpb, *.pbtxt, or *.txtpb files (optionally gzipped), or *.parquet files" && \
-          exit 1 || true
+        set -euo pipefail
+        : "${DATASET_FILE_PATTERN:?must be set by the workflow env}"
+        gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+          --jq '.[].filename' > changed_files.txt
+        echo "Files changed by this pull request:"
+        cat changed_files.txt
+        # Filenames are untrusted input and are only ever matched, never run.
+        if grep -vE "${DATASET_FILE_PATTERN}" changed_files.txt; then
+          echo "Error: submissions should only contain *.pb, *.binpb, *.pbtxt, or *.txtpb files (optionally gzipped), or *.parquet files"
+          exit 1
+        fi
       if: github.event.pull_request.head.repo.fork
 
   process_submission:
@@ -129,9 +140,26 @@ jobs:
         fi
     - name: Identify changed files
       # NOTE(kearnes): This sets the NUM_CHANGED_FILES variable.
+      #
+      # From the API for the same reason as check_file_types: a diff against
+      # upstream/main counts everything merged since this pull request's branch
+      # last caught up, so a submission would be "processed" together with
+      # whatever else had landed. process_dataset.py reads git's --name-status
+      # format, so the statuses are mapped back to it here; only A, D, M, and R
+      # are accepted there, and a rename carries its previous path.
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
       run: |
         cd "${GITHUB_WORKSPACE}"
-        git diff --name-status upstream/main > changed_files.txt
+        gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '
+          .[] | if .status == "renamed"
+                then "R100\t\(.previous_filename)\t\(.filename)"
+                else (if .status == "added" or .status == "copied" then "A"
+                      elif .status == "removed" then "D"
+                      else "M" end) + "\t" + .filename
+                end' > changed_files.txt
         echo "Found $(wc -l < changed_files.txt | tr -d ' ') changed files"
         cat changed_files.txt
         # Use `|| (( $? == 1 ))` in case no lines match (exit code is nonzero).
@@ -171,8 +199,9 @@ jobs:
     #
     # Nested inside the workspace because process_dataset.py has to run with
     # the pull request's working tree as its cwd -- it shells out to git show,
-    # git diff, git mv, and git rm against it. The directory is untracked, which
-    # neither `git diff` against upstream/main nor `git commit -a` picks up.
+    # git mv, and git rm against it. The directory is untracked, so `git commit
+    # -a` leaves it alone, and the file list comes from the API rather than
+    # from the working tree, so it cannot be mistaken for a submitted file.
     # By branch rather than by base.sha: that field records the base as it
     # stood when the pull request was opened or last synchronized, so a
     # submission branch brought up to date afterwards still reports the old

--- a/.github/workflows/submission.yml
+++ b/.github/workflows/submission.yml
@@ -89,6 +89,18 @@ jobs:
         : "${DATASET_FILE_PATTERN:?must be set by the workflow env}"
         gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
           --jq '.[].filename' > changed_files.txt
+        # The files endpoint stops at 3000 no matter how many pages are asked
+        # for, and says nothing when it does. A truncated list here would mean
+        # files silently skipping the check below, so compare it against the
+        # count the pull request itself reports.
+        EXPECTED="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.changed_files')"
+        ACTUAL="$(wc -l < changed_files.txt | tr -d ' ')"
+        if [[ "${ACTUAL}" -ne "${EXPECTED}" ]]; then
+          echo "Error: listed ${ACTUAL} of ${EXPECTED} changed files. The API"
+          echo "caps this endpoint at 3000, so this submission cannot be"
+          echo "checked in one piece; split it into smaller pull requests."
+          exit 1
+        fi
         echo "Files changed by this pull request:"
         cat changed_files.txt
         # Filenames are untrusted input and are only ever matched, never run.
@@ -160,6 +172,17 @@ jobs:
                       elif .status == "removed" then "D"
                       else "M" end) + "\t" + .filename
                 end' > changed_files.txt
+        # See check_file_types: the endpoint truncates at 3000 files without
+        # saying so, and a short list here would mean datasets silently going
+        # unprocessed rather than merely unchecked.
+        EXPECTED="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.changed_files')"
+        ACTUAL="$(wc -l < changed_files.txt | tr -d ' ')"
+        if [[ "${ACTUAL}" -ne "${EXPECTED}" ]]; then
+          echo "Error: listed ${ACTUAL} of ${EXPECTED} changed files. The API"
+          echo "caps this endpoint at 3000, so this submission cannot be"
+          echo "processed in one piece; split it into smaller pull requests."
+          exit 1
+        fi
         echo "Found $(wc -l < changed_files.txt | tr -d ' ') changed files"
         cat changed_files.txt
         # Use `|| (( $? == 1 ))` in case no lines match (exit code is nonzero).


### PR DESCRIPTION
## Summary

Both jobs asked git what a pull request changed by diffing it against `upstream/main`. A submission sits on a `#<number>` branch that drifts behind `main` as other work merges, so that diff counts every intervening merge as a file the submission touched.

#265 was rejected minutes ago for containing `dependabot.yml`, four workflows, and `process_dataset.py` — everything that had landed since its branch last caught up — and its contributor was told submissions may only contain dataset files. The same staleness earlier made `process_submission` read 11 changed files where there were 2, silently processing none of them.

## Changes

- Ask `GET /repos/{repo}/pulls/{n}/files` what the pull request changes. That is the question actually being asked, and it is unaffected by how stale the base is.
- Map the API's statuses back to git's `--name-status` format, which `process_dataset.py` parses: `A`, `D`, `M`, and a rename as `R100` carrying its previous path.
- Drop the checkout and upstream fetch from `check_file_types`, which only ever wanted the list of names.

## Testing

- Ran the jq against #265's real file list: two `A` lines for the two `.binpb` files, where the diff had produced seven.
- Fed both that output and synthetic add/modify/delete/rename lines through `process_dataset._get_inputs`, confirming each parses to the same `FileStatus` as before, including `R100` recovering its previous path.
- All five workflows parse; pre-commit hooks pass; 51 tests pass; the `DATASET_FILE_PATTERN` drift guard still sees two definitions and one value.

## Notes

A merge base would serve too — `git diff $(git merge-base upstream/main HEAD)` — but the `--depth=1` fetch these jobs do leaves no shared history to compute one from, which is likely why the direct diff was chosen originally. Deepening the fetch to make merge-base work would cost more than the API call it replaces.

`process_submission` keeps its upstream remote: `process_dataset.py` still takes `--base=upstream/main` and reads base revisions through `git show`.

This also removes the need to fast-forward a `#<number>` branch before re-running a submission, which until now was the only way to stop these jobs reporting unrelated files.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces stale-branch Git diffs with GitHub’s pull-request file list and now safely rejects truncated API responses.
- Maps API file statuses into the format expected by `process_dataset.py`.
- Checks the returned file count against the pull request’s authoritative changed-file count in both affected jobs.
- Removes the checkout and upstream fetch that the file-type check no longer needs.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/submission.yml | Uses pull-request API file metadata in both submission jobs and adds count-based guards that prevent the 3,000-file API ceiling from silently omitting files. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fail when the API truncates a submission..."](https://github.com/open-reaction-database/ord-data/commit/efbdfe64713a31f76f871a790f7d6832ceb3e233) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49424180)</sub>

<!-- /greptile_comment -->