### PR TITLE
Write new submissions as Parquet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,10 @@ Invariants — easy to break, so check these when editing any workflow or LFS co
    step for fork PRs). Every invalid file is reported, not just the first.
 4. A maintainer merges into the `#<number>` branch; the non-fork run's `Update
    submission` step runs `process_dataset.py --update --cleanup`, which assigns
-   ids and **moves the file into `data/`** (where it becomes an LFS object), then
-   commits and pushes.
+   ids and **moves the file into `data/`** as **Parquet** (where it becomes an
+   LFS object), then commits and pushes. An edit to a dataset already in the
+   repository keeps whatever format it has; only new submissions are written in
+   the standard one.
 5. A maintainer PRs the `#<number>` branch into `main`. On push to `main`,
    `validation.yml` validates and `huggingface_mirror.yml` mirrors the new
    objects to HF.

--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ side of the workflow still runs.
 
 ### Converting datasets to Parquet
 
-Datasets are stored as `.pb.gz`; most also have a Parquet sibling. New
-submissions arrive as `.pb.gz` only, so their Parquet versions are backfilled
-with [`scripts/convert_to_parquet.py`](scripts/convert_to_parquet.py). The
+New submissions are written as Parquet, the standard format. Older datasets are
+stored as `.pb.gz`; most already have a Parquet sibling, and the rest are
+backfilled with [`scripts/convert_to_parquet.py`](scripts/convert_to_parquet.py).
+Editing an existing `.pb.gz` leaves it as `.pb.gz` — converting the corpus is
+this script's job, not a side effect of changing one dataset. The
 script globs every `data/**/*.pb.gz`, merges the known de-shard groups (the
 `uspto-grants-YYYY_MM` monthly buckets and the `C8SC04228D` shards) into single
 outputs, converts everything else 1:1 (carrying the existing `dataset_id`), and

--- a/scripts/process_dataset.py
+++ b/scripts/process_dataset.py
@@ -25,6 +25,12 @@ With --update, the script also performs database-specific updates (such as addin
 record IDs) and writes each dataset to its canonical path under data/. With --cleanup,
 it records those input to output moves in git's index. Contributors preparing a dataset
 should validate with ord_schema.scripts.validate_dataset instead.
+
+Output is Parquet. Submissions may still arrive in any accepted format -- the
+serialized-proto suffixes are convenient to produce -- but what lands under data/ is
+Parquet, which supports random access by row group and streaming iteration without
+holding a whole dataset in memory. The .pb.gz files already in data/ stay where they
+are; --output_format overrides this for a one-off conversion.
 """
 
 import argparse
@@ -387,10 +393,20 @@ def run(
                 len(changed),
             )
         if args.update and dataset is not None and is_valid:
+            # New submissions land in the standard format; a dataset already in
+            # the repository keeps the one it has. Rewriting an edited .pb.gz as
+            # Parquet would rename a published path and delete the .pb.gz, which
+            # is convert_to_parquet.py's decision to make over the corpus as a
+            # whole, not a side effect of correcting a typo in one dataset.
+            output_format = args.output_format
+            if not file_status.status.startswith("A"):
+                output_format = (
+                    _dataset_suffix(file_status.filename) or args.output_format
+                )
             _run_updates(
                 datasets_checked,
                 root=args.root,
-                output_format=args.output_format,
+                output_format=output_format,
                 write_errors=args.write_errors,
                 cleanup_files=args.cleanup,
             )
@@ -441,7 +457,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--root", default="", help="Root of the repository")
     parser.add_argument(
-        "--output_format", default=".pb.gz", help="Dataset output format"
+        "--output_format",
+        default=".parquet",
+        help="Dataset output format (default: .parquet)",
     )
     parser.add_argument(
         "--write_errors",

--- a/scripts/process_dataset.py
+++ b/scripts/process_dataset.py
@@ -26,11 +26,13 @@ record IDs) and writes each dataset to its canonical path under data/. With --cl
 it records those input to output moves in git's index. Contributors preparing a dataset
 should validate with ord_schema.scripts.validate_dataset instead.
 
-Output is Parquet. Submissions may still arrive in any accepted format -- the
-serialized-proto suffixes are convenient to produce -- but what lands under data/ is
-Parquet, which supports random access by row group and streaming iteration without
-holding a whole dataset in memory. The .pb.gz files already in data/ stay where they
-are; --output_format overrides this for a one-off conversion.
+A new submission is written as Parquet, which supports random access by row group and
+streaming iteration without holding a whole dataset in memory. Submissions may still
+arrive in any accepted format -- the serialized-proto suffixes are convenient to
+produce -- but that is what lands under data/. Editing a dataset already in data/
+leaves it in the format it has, so correcting one dataset never renames a published
+path or drops its .pb.gz. Passing --output_format overrides both, which is how a
+deliberate one-off conversion is done.
 """
 
 import argparse
@@ -56,6 +58,9 @@ from ord_schema.logging import get_logger, silence_rdkit_logs
 from ord_schema.proto import dataset_pb2
 
 logger = get_logger(__name__)
+
+# Parquet is the standard on-disk format; see the module docstring.
+DEFAULT_OUTPUT_FORMAT = ".parquet"
 
 
 @dataclasses.dataclass(eq=True, frozen=True, order=True)
@@ -393,15 +398,20 @@ def run(
                 len(changed),
             )
         if args.update and dataset is not None and is_valid:
-            # New submissions land in the standard format; a dataset already in
-            # the repository keeps the one it has. Rewriting an edited .pb.gz as
-            # Parquet would rename a published path and delete the .pb.gz, which
-            # is convert_to_parquet.py's decision to make over the corpus as a
-            # whole, not a side effect of correcting a typo in one dataset.
-            output_format = args.output_format
-            if not file_status.status.startswith("A"):
+            # An explicit --output_format always wins; that is what it is for,
+            # including converting an existing dataset on purpose. Absent one,
+            # a new submission lands in the standard format and a dataset
+            # already in the repository keeps the one it has -- rewriting an
+            # edited .pb.gz as Parquet would rename a published path and delete
+            # the .pb.gz as a side effect of correcting one dataset, which is
+            # convert_to_parquet.py's decision to make over the whole corpus.
+            if args.output_format is not None:
+                output_format = args.output_format
+            elif file_status.status.startswith("A"):
+                output_format = DEFAULT_OUTPUT_FORMAT
+            else:
                 output_format = (
-                    _dataset_suffix(file_status.filename) or args.output_format
+                    _dataset_suffix(file_status.filename) or DEFAULT_OUTPUT_FORMAT
                 )
             _run_updates(
                 datasets_checked,
@@ -458,8 +468,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--root", default="", help="Root of the repository")
     parser.add_argument(
         "--output_format",
-        default=".parquet",
-        help="Dataset output format (default: .parquet)",
+        default=None,
+        help=(
+            f"Dataset output format. Defaults to {DEFAULT_OUTPUT_FORMAT} for a new "
+            "submission and to a dataset's existing format when one is edited; "
+            "setting this overrides both."
+        ),
     )
     parser.add_argument(
         "--write_errors",

--- a/scripts/process_dataset_test.py
+++ b/scripts/process_dataset_test.py
@@ -129,10 +129,10 @@ class TestProcessDataset:
             pathlib.Path(dirname)
             / "data"
             / "00"
-            / "ord_dataset-00000000000000000000000000000000.pb.gz"
+            / "ord_dataset-00000000000000000000000000000000.parquet"
         )
         assert expected_output.exists()
-        dataset = message_helpers.load_message(expected_output, dataset_pb2.Dataset)
+        dataset = parquet.load_dataset(expected_output)
         assert len(dataset.reactions) == 1
         assert dataset.reactions[0].reaction_id.startswith("ord-")
 
@@ -399,12 +399,12 @@ class TestSubmissionWorkflow:
         # Check for assignment of dataset and reaction IDs.
         filenames.pop(filenames.index(dataset_filename))
         assert len(filenames) == 1
-        dataset = message_helpers.load_message(filenames[0], dataset_pb2.Dataset)
+        dataset = parquet.load_dataset(filenames[0])
         assert dataset.dataset_id
         assert len(dataset.reactions) == 1
         assert dataset.reactions[0].reaction_id
-        # Check for binary output.
-        assert filenames[0].endswith(".pb.gz")
+        # Submissions are normalized to the canonical on-disk format.
+        assert filenames[0].endswith(".parquet")
 
     @pytest.mark.parametrize("suffix", [".binpb", ".txtpb"])
     def test_add_dataset_with_protobuf_canonical_suffix(self, setup, suffix):
@@ -436,12 +436,12 @@ class TestSubmissionWorkflow:
         assert not this_dataset_filename.exists()
         assert len(filenames) == 2
         filenames.pop(filenames.index(dataset_filename))
-        written = message_helpers.load_message(filenames[0], dataset_pb2.Dataset)
+        written = parquet.load_dataset(filenames[0])
         assert written.dataset_id
         assert len(written.reactions) == 1
         assert written.reactions[0].reaction_id
         # Submissions are normalized to the canonical on-disk format.
-        assert filenames[0].endswith(".pb.gz")
+        assert filenames[0].endswith(".parquet")
 
     def test_add_parquet_dataset_with_cleanup(self, setup):
         # Exercises --cleanup + .parquet input + .parquet output: the
@@ -516,7 +516,7 @@ class TestSubmissionWorkflow:
         filenames.pop(filenames.index(dataset_filename))
         assert len(filenames) == 2
         for filename in filenames:
-            dataset = message_helpers.load_message(filename, dataset_pb2.Dataset)
+            dataset = parquet.load_dataset(filename)
             assert len(dataset.reactions) == 1
         assert not dataset1_filename.exists()
         assert not dataset2_filename.exists()
@@ -549,7 +549,7 @@ class TestSubmissionWorkflow:
         assert not this_dataset_filename.exists()
         filenames.pop(filenames.index(dataset_filename))
         assert len(filenames) == 1
-        dataset = message_helpers.load_message(filenames[0], dataset_pb2.Dataset)
+        dataset = parquet.load_dataset(filenames[0])
         # Check that existing record IDs for added datasets are not overridden.
         assert dataset.reactions[0].reaction_id == reaction_id
         assert len(dataset.reactions[0].provenance.record_modified) == 0
@@ -579,7 +579,12 @@ class TestSubmissionWorkflow:
         assert added == {"test"}
         assert not removed
         assert changed == {"ord-10aed8b5dffe41fab09f5b2cc9c58ad9"}
+        # Editing a dataset already in the repository leaves it in the format it
+        # has: rewriting it as Parquet would rename a published path and delete
+        # the .pb.gz, which is a corpus-wide decision rather than a side effect
+        # of correcting one dataset. New submissions get the standard format.
         assert filenames == [dataset_filename]
+        assert dataset_filename.endswith(".pb.gz")
         # Check for preservation of dataset and record IDs.
         updated_dataset = message_helpers.load_message(
             dataset_filename, dataset_pb2.Dataset

--- a/scripts/process_dataset_test.py
+++ b/scripts/process_dataset_test.py
@@ -596,6 +596,20 @@ class TestSubmissionWorkflow:
         )
         assert updated_dataset.reactions[1].reaction_id
 
+    def test_modify_dataset_with_explicit_output_format(self, setup):
+        # --output_format is how a deliberate one-off conversion is requested,
+        # so it has to beat the preservation rule above rather than lose to it.
+        test_subdirectory, dataset_filename = setup
+        dataset = message_helpers.load_message(dataset_filename, dataset_pb2.Dataset)
+        dataset.reactions[0].inputs["methylamine"].components[0].amount.moles.value = 2
+        message_helpers.save_message(dataset, dataset_filename)
+        _, _, _, filenames = self._run(
+            test_subdirectory, ["--output_format", ".parquet"]
+        )
+        assert not pathlib.Path(dataset_filename).exists()
+        assert filenames == [dataset_filename.replace(".pb.gz", ".parquet")]
+        assert len(parquet.load_dataset(filenames[0]).reactions) == 1
+
     def test_modify_reaction_id(self, setup):
         test_subdirectory, dataset_filename = setup
         dataset = message_helpers.load_message(dataset_filename, dataset_pb2.Dataset)


### PR DESCRIPTION
## Summary

Parquet is the standard format — random access by row group, streaming iteration without holding a dataset in memory, which is why `process_dataset.py` already *reads* it that way. Submissions still arrive in whichever accepted format is convenient to produce, but what lands under `data/` is now Parquet rather than `.pb.gz`.

## Changes

- `--output_format` defaults to `.parquet`.
- Scoped to **new** submissions: editing a dataset already in the repository leaves it in the format it has.
- README and CLAUDE.md updated to match.

## Testing

- 51 tests pass. The two end-to-end submission tests now assert a `.parquet` result and load it with `parquet.load_dataset`; `test_modify_dataset` gains an explicit assertion that an edited `.pb.gz` stays `.pb.gz`, so the preservation rule cannot be lost to a later refactor.
- `ord_schema.datasets.save_dataset` already dispatches `.parquet` to `parquet.save_dataset`, and `.gitattributes` already tracks `data/**/*.parquet` in LFS, so neither needed changing.

## Notes

The scoping is the part worth reviewing. Flipping the default alone made `--cleanup` `git mv` an edited `.pb.gz` to `.parquet` — renaming a published dataset path and deleting the `.pb.gz` as a side effect of correcting one dataset. Four tests caught it. Converting the corpus is `convert_to_parquet.py`'s job and a deliberate, reviewable decision; it should not happen incidentally.

If you *do* want migrate-on-edit, it is a one-line change (drop the `status.startswith("A")` check) — but it would delete `.pb.gz` files one at a time, which runs against keeping them deprecated rather than removed.

`--output_format` still overrides both behaviors for a one-off conversion.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes Parquet the default storage format for new submissions while preserving the current format of edited datasets and honoring explicit conversions.

- Selects the output format independently for each processed dataset.
- Gives `--output_format` precedence over new-submission and format-preservation defaults.
- Updates workflow documentation and tests for Parquet output, preservation, and explicit conversion.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported explicit-format defect is fixed because `args.output_format` now takes precedence before either default-format branch, and the regression test exercises conversion of an existing `.pb.gz` dataset to Parquet.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/process_dataset.py | Implements per-dataset output-format selection with explicit CLI overrides taking precedence over Parquet defaults and existing-format preservation. |
| scripts/process_dataset_test.py | Updates submission expectations to Parquet and adds coverage proving that edits preserve protobuf unless an explicit Parquet conversion is requested. |
| README.md | Documents Parquet as the standard format for new submissions and clarifies that existing protobuf datasets are not converted on edit. |
| CLAUDE.md | Updates repository workflow guidance to describe Parquet output for new submissions and format preservation for edits. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Process valid dataset with --update] --> B{Explicit --output_format?}
    B -->|Yes| C[Use requested format]
    B -->|No| D{Newly added file?}
    D -->|Yes| E[Write Parquet]
    D -->|No| F[Preserve existing suffix]
    C --> G[Run updates and write canonical path]
    E --> G
    F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Let an explicit --output\_format beat for..."](https://github.com/open-reaction-database/ord-data/commit/f63d8fc948f255df34b5635c11ea46d11e3fcda6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49426913)</sub>

<!-- /greptile_comment -->