### PR TITLE
Validate the corpus with the locked ord_schema

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -20,12 +20,9 @@ on:
   push:
     branches:
       - main
-    # Every merge used to re-validate the whole corpus: 2.4 GB of Git LFS
-    # across 603 files, pulled from GitHub rather than the Hugging Face mirror
-    # (see the fetch step for why that has to be GitHub). Most merges here
-    # change workflows or scripts and no data at all, so that bandwidth bought
-    # nothing. Validate on a push only when the data, or the thing that
-    # validates it, actually changed.
+    # Validating the whole corpus pulls 2.4 GB of Git LFS across 603 files from
+    # GitHub (see the fetch step for why it has to be GitHub), so a push pays
+    # for it only when the data, or the thing that validates it, changed.
     paths:
       - 'data/**'
       - '.github/workflows/validation.yml'
@@ -34,10 +31,9 @@ on:
       # Runs when this file is modified in a PR.
       - '.github/workflows/validation.yml'
   schedule:
-    # The per-merge run was also, incidentally, a standing sweep for bit rot
-    # and for corruption arriving by some path other than a dataset commit.
-    # Narrowing the push trigger would drop that, so it moves here: 07:00 UTC
-    # on Mondays, whole corpus, no merge waiting on it.
+    # Standing sweep for bit rot, and for corruption arriving by some path
+    # other than a dataset commit: the whole corpus, with no merge waiting on
+    # it.
     - cron: '0 7 * * 1'
 
 # One in-flight matrix per PR (or per push to main). Subsequent events
@@ -51,9 +47,12 @@ concurrency:
   group: validation-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  ORD_SCHEMA_TAG: v0.6.3
-
+# validate_dataset.py ships inside the ord_schema wheel, so both jobs below run
+# it as a module out of the `pipeline` dependency group. uv.lock is therefore
+# the only place the schema version is written down, and it is the same
+# resolution the submission pipeline validates against: a dataset is checked
+# against one version of the schema library whether it arrives by submission or
+# is swept here.
 jobs:
   validate_pb:
     runs-on: ubuntu-latest
@@ -92,28 +91,39 @@ jobs:
       run: |
         git config lfs.url "https://github.com/${GITHUB_REPOSITORY}.git/info/lfs"
         git lfs pull --include="${FILTER}/*.pb*"
-    - name: Checkout ord-schema
+    # A pull_request run checks out the merge ref, so the tree above is
+    # contributor-controlled, uv.lock included. The environment is built from a
+    # ref this repository owns instead: the base branch on a pull request, the
+    # pushed or scheduled ref otherwise.
+    - name: Check out the pipeline from a trusted ref
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        repository: Open-Reaction-Database/ord-schema
-        ref: ${{ env.ORD_SCHEMA_TAG }}
-        path: ord-schema
-    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        ref: ${{ github.event.pull_request.base.ref || github.ref }}
+        path: pipeline
+        lfs: false
+        # Only what `uv sync` reads. Leaving out data/ also keeps a second tree
+        # of dataset pointer files from sitting under the workspace.
+        sparse-checkout: |
+          .python-version
+          pyproject.toml
+          uv.lock
+        sparse-checkout-cone-mode: false
+    - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
-        python-version: '3.11'
+        enable-cache: true
     - name: Install ord_schema
-      run: |
-        cd "${GITHUB_WORKSPACE}/ord-schema"
-        python -m pip install --upgrade pip
-        python -m pip install wheel
-        python -m pip install .
+      working-directory: pipeline
+      run: uv sync --only-group pipeline --locked
+    # The interpreter is invoked directly rather than through `uv run`, which
+    # would rediscover the checked-out tree's own pyproject.toml and hand the
+    # environment back to the pull request.
     - name: Validate datasets
       env:
         FILTER: ${{ matrix.filter }}
       run: |
         cd "${GITHUB_WORKSPACE}"
-        python ./ord-schema/ord_schema/scripts/validate_dataset.py \
-          --input="data/*/*.pb*" \
+        ./pipeline/.venv/bin/python -m ord_schema.scripts.validate_dataset \
+          --input_pattern="data/*/*.pb*" \
           --filter="${FILTER}" \
           --n_jobs=4
 
@@ -153,27 +163,33 @@ jobs:
         else
           git lfs pull --include="${LFS_INCLUDE}"
         fi
-    - name: Checkout ord-schema
+    # See validate_pb: the environment comes from a ref this repository owns,
+    # never the contributor-controlled merge ref.
+    - name: Check out the pipeline from a trusted ref
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        repository: Open-Reaction-Database/ord-schema
-        ref: ${{ env.ORD_SCHEMA_TAG }}
-        path: ord-schema
-    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        ref: ${{ github.event.pull_request.base.ref || github.ref }}
+        path: pipeline
+        lfs: false
+        # Only what `uv sync` reads. Leaving out data/ also keeps a second tree
+        # of dataset pointer files from sitting under the workspace.
+        sparse-checkout: |
+          .python-version
+          pyproject.toml
+          uv.lock
+        sparse-checkout-cone-mode: false
+    - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
-        python-version: '3.11'
+        enable-cache: true
     - name: Install ord_schema
-      run: |
-        cd "${GITHUB_WORKSPACE}/ord-schema"
-        python -m pip install --upgrade pip
-        python -m pip install wheel
-        python -m pip install .
+      working-directory: pipeline
+      run: uv sync --only-group pipeline --locked
     - name: Validate parquet datasets
       env:
         FILTER: ${{ matrix.filter }}
       run: |
         cd "${GITHUB_WORKSPACE}"
-        python ./ord-schema/ord_schema/scripts/validate_dataset.py \
-          --input="data/*/*.parquet" \
+        ./pipeline/.venv/bin/python -m ord_schema.scripts.validate_dataset \
+          --input_pattern="data/*/*.parquet" \
           --filter="${FILTER}" \
           --n_jobs=4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,12 @@ Python style, etc.).
   `data/<xx>/ord_dataset-<uuid>.{pb.gz,parquet}`, sharded into 256 directories
   by the first two hex chars of the dataset id.
 - Large dataset files are stored with **Git LFS**. The schema library lives in
-  `Open-Reaction-Database/ord-schema`. `validate_dataset.py` still comes from
-  there, pinned by `ORD_SCHEMA_TAG` in `validation.yml`; `process_dataset.py`
-  lives here in `scripts/` and gets its dependencies from the `pipeline`
-  dependency group.
+  `Open-Reaction-Database/ord-schema` and is installed from PyPI by the
+  `pipeline` dependency group, so **`uv.lock` is the only place its version is
+  written down** — `validation.yml` runs `validate_dataset.py` out of the
+  installed wheel (`python -m ord_schema.scripts.validate_dataset`) rather than
+  pinning a tag of its own, so submission-time and merge-time validation cannot
+  disagree. `process_dataset.py` lives here in `scripts/`.
 
 ## Local checks
 
@@ -73,14 +75,17 @@ the whole dataset, so submission CI only needs the **changed** objects.
 
 - **`validation.yml`** — validates every dataset. Triggers on push to `main`
   **only under `data/**`**, on PRs that touch `validation.yml`, and weekly
-  (Mon 07:00 UTC) for the full sweep — a workflow-only merge no longer pulls
+  (Mon 07:00 UTC) for the full sweep, so a workflow-only merge does not pull
   2.4 GB of LFS to validate data nobody changed. 11-shard matrix: 9 `validate_pb` shards by
   `data/<hex><hex>` prefix + 2 `validate_parquet` (uspto / other). Each shard
   sparse-pulls only its objects from GitHub. For pb shards, `matrix.filter`
   doubles as both the `validate_dataset.py` regex and the LFS `--include` glob
   (parquet needs a separate `lfs_include` because its filter is a lookahead
   regex). Uses `concurrency: cancel-in-progress` — pushing again cancels the
-  running matrix.
+  running matrix. Like `submission.yml`, it builds its environment from a
+  repo-owned ref (`pipeline/`, sparse-checked-out to just `.python-version` /
+  `pyproject.toml` / `uv.lock`) because a `pull_request` run checks out the
+  contributor-controlled merge ref.
 - **`submission.yml`** — per-PR. `process_submission` sparse-pulls only the
   changed datasets, gated on `NUM_CHANGED_FILES`. Fork PRs run validate-only;
   non-fork PRs run the `Update submission` step (skippable via the


### PR DESCRIPTION
## Summary

`validation.yml` pinned `ORD_SCHEMA_TAG: v0.6.3` (May 12) while `uv.lock` resolved ord-schema to 0.8.0 (Jul 24), so submissions were validated against one version of the schema library and the corpus against another — a dataset could pass at submission time and fail on merge. `validate_dataset.py` ships inside the ord_schema wheel, so both jobs now run it as a module out of the `pipeline` dependency group and `uv.lock` is the only place the version is written down.

## Changes

- Drop the `ord-schema` checkout, the `ORD_SCHEMA_TAG` env, the separate `setup-python`, and the `pip install .` from both `validate_pb` and `validate_parquet`; run `python -m ord_schema.scripts.validate_dataset` from the synced venv instead.
- Build that venv from a ref this repository owns (`pipeline/`, base branch on a PR and the pushed/scheduled ref otherwise), matching `submission.yml` — this workflow runs on PRs that touch it, and a `pull_request` run checks out the contributor-controlled merge ref. The checkout is sparse: only `.python-version`, `pyproject.toml`, `uv.lock`.
- `--input` → `--input_pattern` (the old name is a deprecated alias in 0.8.0).
- Trim historical narration from the trigger comments.

## Testing

Reproduced the CI environment locally — sparse tree of the three files, `uv sync --only-group pipeline --locked` (resolves Python 3.11.15 from `.python-version`) — and ran both jobs' exact invocations against materialized LFS objects: one `.pb.gz` via the `validate_pb` path and one `.parquet` through the `validate_parquet` negative-lookahead filter. Both exit 0, and row-group parallelism still engages on the parquet path. `pytest -n auto` (52 passed), `ruff check`/`format`, `ty`, and `pre-commit run --all-files` are clean.

This PR touches `validation.yml`, so its own run is the full 11-shard matrix under 0.8.0 — the isolated sweep that shows whether the newer library finds anything v0.6.3 let through.

## Notes

Once ord-schema #922 (`--shard`) is released, picking it up is a `uv lock --upgrade-package ord-schema` here rather than a second pin to keep in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes corpus validation use the same locked ord-schema dependency as the submission pipeline, eliminating the separate workflow-level schema pin.
- Checks out a sparse, repository-owned pipeline configuration for dependency installation.
- Runs the wheel-provided validator module from the resulting locked virtual environment.
- Updates the validator argument to `--input_pattern`.
- Documents the unified dependency and workflow behavior in `CLAUDE.md`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with corpus and submission validation consistently using the repository's locked ord-schema dependency.

The configured event refs resolve to repository-owned revisions, the sparse checkout includes all files required for the virtual pipeline project, and both validation jobs invoke the locked validator without disturbing or broadening their existing corpus shards.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/validation.yml | Replaces the independent ord-schema checkout and pin with a sparse trusted checkout, locked pipeline environment, and module-based validator invocation; no actionable defect was identified. |
| CLAUDE.md | Updates repository guidance to describe the unified locked schema dependency and trusted sparse-checkout workflow. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Event as GitHub event
    participant Corpus as Corpus checkout
    participant Pipeline as Trusted pipeline checkout
    participant UV as uv sync
    participant Validator as ord_schema validator
    Event->>Corpus: Check out merge/push tree
    Corpus->>Corpus: Pull selected LFS shard from GitHub
    Event->>Pipeline: Check out base ref or triggering ref
    Pipeline->>UV: Sync locked pipeline dependency group
    UV->>Validator: Provide pipeline/.venv Python
    Validator->>Corpus: Validate matching PB or Parquet files
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Validate the corpus with the locked ord\_..."](https://github.com/open-reaction-database/ord-data/commit/6e1bcb629bcab39ef78208fe3d45f2a63b73e0c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49518939)</sub>

<!-- /greptile_comment -->