### PR TITLE
Use American spelling in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Python style, etc.).
 
 `uv run pytest -n auto` · `uv run ruff check .` · `uv run ty check` ·
 `uv run pre-commit run --all-files`. Python is pinned to 3.11 by
-`.python-version`; `uv sync --locked` honours it.
+`.python-version`; `uv sync --locked` honors it.
 
 ## Git LFS ↔ Hugging Face mirror — read before touching LFS or workflows
 


### PR DESCRIPTION
One word: "honours" → "honors".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR standardizes American English spelling in the repository guidance.
- Replaces “honours” with “honors” in `CLAUDE.md`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The change is documentation-only and preserves the meaning and accuracy of the existing `uv sync --locked` guidance.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Updates one word to American spelling without changing the documented command or its meaning. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Use American spelling in CLAUDE.md"](https://github.com/open-reaction-database/ord-data/commit/41f3e5aafb03f9c8e6e53f71ef92b2bb667dc1d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49527821)</sub>

<!-- /greptile_comment -->