### PR TITLE
Pick up ord-schema 0.8.2, validate ids, and let a dependency bump test itself

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -93,14 +93,18 @@ jobs:
       run: |
         git config lfs.url "https://github.com/${GITHUB_REPOSITORY}.git/info/lfs"
         git lfs pull --include="${FILTER}/*.pb*"
-    # A pull_request run checks out the merge ref, so the tree above is
-    # contributor-controlled, uv.lock included. The environment is built from a
-    # ref this repository owns instead: the base branch on a pull request, the
-    # pushed or scheduled ref otherwise.
-    - name: Check out the pipeline from a trusted ref
+    # A fork's pull request must not choose the environment its own data is
+    # validated in, so a fork run builds from the base branch. Every other run
+    # builds from the ref under test -- for a same-repo pull request that is the
+    # merge ref, so a change to uv.lock and a change to how the validator is
+    # invoked can land together and actually be tested. Anyone who can open a
+    # same-repo pull request can already edit this file.
+    - name: Check out the pipeline
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        ref: ${{ github.event.pull_request.base.ref || github.ref }}
+        ref: >-
+          ${{ github.event.pull_request.head.repo.fork
+              && github.event.pull_request.base.ref || github.sha }}
         path: pipeline
         lfs: false
         # Only what `uv sync` reads. Leaving out data/ also keeps a second tree
@@ -166,12 +170,14 @@ jobs:
         else
           git lfs pull --include="${LFS_INCLUDE}"
         fi
-    # See validate_pb: the environment comes from a ref this repository owns,
-    # never the contributor-controlled merge ref.
-    - name: Check out the pipeline from a trusted ref
+    # See validate_pb: forks build from the base branch, everything else from
+    # the ref under test.
+    - name: Check out the pipeline
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        ref: ${{ github.event.pull_request.base.ref || github.ref }}
+        ref: >-
+          ${{ github.event.pull_request.head.repo.fork
+              && github.event.pull_request.base.ref || github.sha }}
         path: pipeline
         lfs: false
         # Only what `uv sync` reads. Leaving out data/ also keeps a second tree

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -48,7 +48,9 @@ concurrency:
   cancel-in-progress: true
 
 # validate_dataset.py ships inside the ord_schema wheel, so both jobs below run
-# it as a module out of the `pipeline` dependency group. uv.lock is therefore
+# it as a module out of the `pipeline` dependency group. Both pass --validate_ids,
+# matching what process_dataset.py checks when a dataset is submitted, so an id
+# that stopped being well-formed after submission does not go unnoticed. uv.lock is therefore
 # the only place the schema version is written down, and it is the same
 # resolution the submission pipeline validates against: a dataset is checked
 # against one version of the schema library whether it arrives by submission or
@@ -125,7 +127,8 @@ jobs:
         ./pipeline/.venv/bin/python -m ord_schema.scripts.validate_dataset \
           --input_pattern="data/*/*.pb*" \
           --filter="${FILTER}" \
-          --n_jobs=4
+          --n_jobs=4 \
+          --validate_ids
 
   validate_parquet:
     runs-on: ubuntu-latest
@@ -192,4 +195,5 @@ jobs:
         ./pipeline/.venv/bin/python -m ord_schema.scripts.validate_dataset \
           --input_pattern="data/*/*.parquet" \
           --filter="${FILTER}" \
-          --n_jobs=4
+          --n_jobs=4 \
+          --validate_ids

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -49,8 +49,8 @@ concurrency:
 
 # validate_dataset.py ships inside the ord_schema wheel, so both jobs below run
 # it as a module out of the `pipeline` dependency group. Both pass --validate_ids,
-# matching what process_dataset.py checks when a dataset is submitted, so an id
-# that stopped being well-formed after submission does not go unnoticed. uv.lock is therefore
+# matching what process_dataset.py checks at submission, so an id that stops being
+# well-formed afterwards does not go unnoticed. uv.lock is therefore
 # the only place the schema version is written down, and it is the same
 # resolution the submission pipeline validates against: a dataset is checked
 # against one version of the schema library whether it arrives by submission or
@@ -95,10 +95,10 @@ jobs:
         git lfs pull --include="${FILTER}/*.pb*"
     # A fork's pull request must not choose the environment its own data is
     # validated in, so a fork run builds from the base branch. Every other run
-    # builds from the ref under test -- for a same-repo pull request that is the
-    # merge ref, so a change to uv.lock and a change to how the validator is
-    # invoked can land together and actually be tested. Anyone who can open a
-    # same-repo pull request can already edit this file.
+    # builds from github.sha -- the merge commit on a pull request -- so a
+    # uv.lock bump and a change to how the validator is invoked are tested
+    # together. Anyone who can open a same-repo pull request can already edit
+    # this file.
     - name: Check out the pipeline
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -171,7 +171,7 @@ jobs:
           git lfs pull --include="${LFS_INCLUDE}"
         fi
     # See validate_pb: forks build from the base branch, everything else from
-    # the ref under test.
+    # github.sha.
     - name: Check out the pipeline
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,10 @@ the whole dataset, so submission CI only needs the **changed** objects.
   sparse-pulls only its objects from GitHub. For pb shards, `matrix.filter`
   doubles as both the `validate_dataset.py` regex and the LFS `--include` glob
   (parquet needs a separate `lfs_include` because its filter is a lookahead
-  regex). Uses `concurrency: cancel-in-progress` — pushing again cancels the
+  regex). Both jobs pass `--validate_ids`, matching what `process_dataset.py`
+  checks at submission; the flag is opt-in in `ord_schema` because ids are
+  assigned *during* submission, so a draft does not have them yet. Uses
+  `concurrency: cancel-in-progress` — pushing again cancels the
   running matrix. Like `submission.yml`, it builds its environment from a
   repo-owned ref (`pipeline/`, sparse-checked-out to just `.python-version` /
   `pyproject.toml` / `uv.lock`) because a `pull_request` run checks out the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,17 +82,16 @@ the whole dataset, so submission CI only needs the **changed** objects.
   doubles as both the `validate_dataset.py` regex and the LFS `--include` glob
   (parquet needs a separate `lfs_include` because its filter is a lookahead
   regex). Both jobs pass `--validate_ids`, matching what `process_dataset.py`
-  checks at submission; the flag is opt-in in `ord_schema` because ids are
-  assigned *during* submission, so a draft does not have them yet. Uses
-  `concurrency: cancel-in-progress` — pushing again cancels the
-  running matrix. Its environment is a separate sparse checkout (`pipeline/`,
-  just `.python-version` / `pyproject.toml` / `uv.lock`) taken from the **base
-  branch on fork PRs** and from `github.sha` otherwise. Narrower than
-  `submission.yml`'s guard on purpose: pinning it to the base branch on
-  *every* PR meant the workflow file came from the merge ref while its
-  environment came from `main`, so a PR that bumped `uv.lock` **and** changed
-  the validator's command line failed with `unrecognized arguments` and could
-  not test itself.
+  checks at submission; it is opt-in upstream because ids are assigned *during*
+  submission, so a draft does not have them yet. Uses
+  `concurrency: cancel-in-progress` — pushing again cancels the running matrix.
+  Its environment is a separate sparse checkout (`pipeline/`, just
+  `.python-version` / `pyproject.toml` / `uv.lock`) taken from the **base branch
+  on fork PRs** and from `github.sha` otherwise — deliberately narrower than
+  `submission.yml`'s guard. Pinning it to the base branch on every PR takes the
+  workflow file from the merge ref and its environment from `main`, so a PR that
+  bumps `uv.lock` **and** changes the validator's command line cannot test
+  itself.
 - **`submission.yml`** — per-PR. `process_submission` sparse-pulls only the
   changed datasets, gated on `NUM_CHANGED_FILES`. Fork PRs run validate-only;
   non-fork PRs run the `Update submission` step (skippable via the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,10 +85,14 @@ the whole dataset, so submission CI only needs the **changed** objects.
   checks at submission; the flag is opt-in in `ord_schema` because ids are
   assigned *during* submission, so a draft does not have them yet. Uses
   `concurrency: cancel-in-progress` — pushing again cancels the
-  running matrix. Like `submission.yml`, it builds its environment from a
-  repo-owned ref (`pipeline/`, sparse-checked-out to just `.python-version` /
-  `pyproject.toml` / `uv.lock`) because a `pull_request` run checks out the
-  contributor-controlled merge ref.
+  running matrix. Its environment is a separate sparse checkout (`pipeline/`,
+  just `.python-version` / `pyproject.toml` / `uv.lock`) taken from the **base
+  branch on fork PRs** and from `github.sha` otherwise. Narrower than
+  `submission.yml`'s guard on purpose: pinning it to the base branch on
+  *every* PR meant the workflow file came from the merge ref while its
+  environment came from `main`, so a PR that bumped `uv.lock` **and** changed
+  the validator's command line failed with `unrecognized arguments` and could
+  not test itself.
 - **`submission.yml`** — per-PR. `process_submission` sparse-pulls only the
   changed datasets, gated on `NUM_CHANGED_FILES`. Fork PRs run validate-only;
   non-fork PRs run the `Update submission` step (skippable via the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 # group rather than runtime dependencies so the mirror job, which only moves
 # bytes, can `uv sync --no-dev` without pulling rdkit/pandas.
 pipeline = [
-    "ord-schema>=0.8",
+    "ord-schema>=0.8.2",
     # process_dataset.py posts submission summaries back to a GitHub issue.
     "pygithub>=1.51",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -651,7 +651,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "ord-schema", specifier = ">=0.8" },
+    { name = "ord-schema", specifier = ">=0.8.2" },
     { name = "pre-commit", specifier = ">=4" },
     { name = "pygithub", specifier = ">=1.51" },
     { name = "pytest", specifier = ">=8.0" },
@@ -660,13 +660,13 @@ dev = [
     { name = "ty", specifier = ">=0.0.65" },
 ]
 pipeline = [
-    { name = "ord-schema", specifier = ">=0.8" },
+    { name = "ord-schema", specifier = ">=0.8.2" },
     { name = "pygithub", specifier = ">=1.51" },
 ]
 
 [[package]]
 name = "ord-schema"
-version = "0.8.0"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -680,9 +680,9 @@ dependencies = [
     { name = "rdkit" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/6f/caa03e4654e9c70dda54fccc9c108e3174e157828118af440612b3f35ca8/ord_schema-0.8.0.tar.gz", hash = "sha256:4b4587004b0b3a4ae8e8065df6525ca2144da84933ca570a6385ebb7ef45314d", size = 194944, upload-time = "2026-07-24T02:37:17.393Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/a6/4badad57269902542955a964427160e23af4b79a1dfaf40811f220744204/ord_schema-0.8.2.tar.gz", hash = "sha256:b70f8456acc159609b47e44b485b235a881dcee0b41659802c82034fd6048be3", size = 196701, upload-time = "2026-08-03T00:45:44.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/ca/54588f592a3d3a438541671f598893e7177690efb7dd22f055e3b68e124f/ord_schema-0.8.0-py3-none-any.whl", hash = "sha256:55c23e464800e5cdd14d637653ba0283a3fa1b72aca3c89494c34864a762c56b", size = 223167, upload-time = "2026-07-24T02:37:15.758Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1a/fd49402fe6a7396ed3395f1366e6df6ab05498151f80ca049de46dc5aab7/ord_schema-0.8.2-py3-none-any.whl", hash = "sha256:784e1e53ccf8e32f2e256551aa7cdedd999eb27e95cf0d7358aede1981de81c2", size = 221810, upload-time = "2026-08-03T00:45:43.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Moves the `ord-schema` pin from `>=0.8` to `>=0.8.2`, has both validation jobs pass the new `--validate_ids` flag, and fixes the guard that stopped a PR like this one from testing itself.

0.8.2 carries the validation speedups — identifier parsing memoized, and findings collected through an explicit context instead of the `warnings` module — together **2.84×** on the uspto file, which is the long pole of every full-corpus run (~75 min of the last one).

## Changes

- `ord-schema>=0.8.2` in `pyproject.toml`, `uv.lock` relocked.
- Both `validate_pb` and `validate_parquet` pass `--validate_ids`. Submissions are validated with `validate_ids=True` in `process_dataset.py`, so ids are well-formed on the way in, but the sweep ran with the defaults and never looked at them again — an id that stopped being valid after submission would have passed forever. The flag is opt-in upstream because ids are assigned *during* submission, so a draft does not have them yet.
- **The `pipeline/` checkout now comes from `github.sha` except on fork PRs.** It was pinned to the base branch on every PR, but the workflow file itself comes from the merge ref — so the first push of this PR ran main's `uv.lock` (ord-schema 0.8.0) against its own command line and every shard died on `unrecognized arguments: --validate_ids`. The guard only ever needed to stop a **fork** from choosing the environment its own data is validated in; anyone who can open a same-repo PR can already edit this file.
- CLAUDE.md records the flag, and why this guard is deliberately narrower than `submission.yml`'s.

## Testing

`pytest -n auto` (52 passed), `ruff check`, `ty`, and `pre-commit` all clean against 0.8.2 — that release's API changes (`ValidationError` is now an `Exception`, `ValidationWarning` removed, leaf validators private) touch nothing this repository uses.

Ran the exact command CI runs — `python -m ord_schema.scripts.validate_dataset --input_pattern="data/*/*.parquet" --validate_ids --n_jobs=4` — over the whole local parquet corpus under 0.8.2: 53 datasets, 2466 row groups, exit 0. Beforehand I checked that all 552 corpus dataset ids and 13,108 sampled reaction ids are well-formed, so the flag is a no-op today and a guard from here on.

This PR touches `validation.yml`, so its own run is the full 11-shard matrix — which is also the first real test of `--validate_ids` against the 550 `.pb.gz` datasets I could not materialize locally.

## Expect more warnings, not more errors

The sweep will report roughly **315 new "leading or trailing whitespace" warnings** across the corpus. Those come from [ord-schema#917](https://github.com/open-reaction-database/ord-schema/pull/917), which landed between 0.8.0 and 0.8.1 — not from the validation refactors. I compared 54 datasets across four builds (pinned 0.8.0, the commit before the refactors, `main`, and the refactor branch): the refactors change **no findings at all**, once #927's deliberate reformat of the inconsistent-identifiers message is normalized. They are warnings, so validation still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR upgrades the validation pipeline to `ord-schema` 0.8.2 and enables identifier validation during both protobuf and Parquet corpus sweeps.
- Passes `--validate_ids` in both validation jobs.
- Uses the merge commit’s dependency environment for same-repository pull requests while preserving the base-branch environment for fork pull requests.
- Updates the dependency declaration, lockfile, and workflow documentation.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/validation.yml | Enables identifier validation and correctly aligns same-repository PR commands with their locked schema environment while retaining the fork trust boundary. |
| pyproject.toml | Raises the pipeline dependency floor to ord-schema 0.8.2. |
| uv.lock | Relocks ord-schema at 0.8.2 with consistent dependency metadata and package hashes. |
| CLAUDE.md | Documents identifier validation and the workflow’s fork-aware pipeline checkout behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Distill the comments this branch added"](https://github.com/open-reaction-database/ord-data/commit/d6b53bc06fec81d8982ed4e93c67c89e4d108fa8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49542629)</sub>

<!-- /greptile_comment -->