### PR TITLE
Read reaction IDs through the DatasetView method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 # group rather than runtime dependencies so the mirror job, which only moves
 # bytes, can `uv sync --no-dev` without pulling rdkit/pandas.
 pipeline = [
-    "ord-schema>=0.8.2",
+    "ord-schema>=0.8.3",
     # process_dataset.py posts submission summaries back to a GitHub issue.
     "pygithub>=1.51",
 ]

--- a/scripts/process_dataset.py
+++ b/scripts/process_dataset.py
@@ -144,7 +144,7 @@ def _get_reaction_ids(
     file so we never decode Reaction blobs just to collect IDs.
     """
     if isinstance(dataset, parquet.DatasetView):
-        return {rid for rid in parquet.iter_reaction_ids(dataset.path) if rid}
+        return {rid for rid in dataset.iter_reaction_ids() if rid}
     return {
         reaction.reaction_id for reaction in dataset.reactions if reaction.reaction_id
     }

--- a/scripts/process_dataset.py
+++ b/scripts/process_dataset.py
@@ -304,8 +304,10 @@ def _run_updates(
         # In-memory path: materialize a Parquet input if the requested output
         # format is not Parquet (so we can mutate via update_dataset).
         if isinstance(dataset, parquet.DatasetView):
-            # (materialize the view in place)
-            dataset = parquet.load_dataset(input_filename)  # noqa: PLW2901
+            # to_proto carries the view's own scalars, so an assignment made to the
+            # view survives materialization; re-reading the path would take them
+            # from the footer and drop it.
+            dataset = dataset.to_proto()  # noqa: PLW2901
         updates.update_dataset(dataset)
         validations.validate_datasets(
             {input_filename: dataset}, write_errors, options=options

--- a/uv.lock
+++ b/uv.lock
@@ -651,7 +651,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "ord-schema", specifier = ">=0.8.2" },
+    { name = "ord-schema", specifier = ">=0.8.3" },
     { name = "pre-commit", specifier = ">=4" },
     { name = "pygithub", specifier = ">=1.51" },
     { name = "pytest", specifier = ">=8.0" },
@@ -660,13 +660,13 @@ dev = [
     { name = "ty", specifier = ">=0.0.65" },
 ]
 pipeline = [
-    { name = "ord-schema", specifier = ">=0.8.2" },
+    { name = "ord-schema", specifier = ">=0.8.3" },
     { name = "pygithub", specifier = ">=1.51" },
 ]
 
 [[package]]
 name = "ord-schema"
-version = "0.8.2"
+version = "0.8.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -680,9 +680,9 @@ dependencies = [
     { name = "rdkit" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/a6/4badad57269902542955a964427160e23af4b79a1dfaf40811f220744204/ord_schema-0.8.2.tar.gz", hash = "sha256:b70f8456acc159609b47e44b485b235a881dcee0b41659802c82034fd6048be3", size = 196701, upload-time = "2026-08-03T00:45:44.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ed/9e27e85b9813303bb66eff8aeb3e278c337b9f776c0aac804e003299c481/ord_schema-0.8.3.tar.gz", hash = "sha256:3c1ce2c9f390b7f5c3c692100b322406858a253d5888e895399edc3b31ee7f41", size = 209931, upload-time = "2026-08-04T04:44:18.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/1a/fd49402fe6a7396ed3395f1366e6df6ab05498151f80ca049de46dc5aab7/ord_schema-0.8.2-py3-none-any.whl", hash = "sha256:784e1e53ccf8e32f2e256551aa7cdedd999eb27e95cf0d7358aede1981de81c2", size = 221810, upload-time = "2026-08-03T00:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cc/33eefbca1cd58ec8c42896b8c87e586a58aeb20b58972c4c9416e135ce89/ord_schema-0.8.3-py3-none-any.whl", hash = "sha256:1aaf40d6ce2531f56aca228064e1c26f3ad8d08e5f89731605c8cf1e4bd4867f", size = 232477, upload-time = "2026-08-04T04:44:17.494Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

ord-schema moved `iter_reaction_ids` off the module and onto `DatasetView` (open-reaction-database/ord-schema#931, merged). `_get_reaction_ids` already holds the view, so the call becomes a method on it instead of a module function taking its path.

Requires ord-schema 0.8.3, which this bumps the floor to.

## Changes

- `parquet.iter_reaction_ids(dataset.path)` → `dataset.iter_reaction_ids()` in `_get_reaction_ids`.
- The in-memory path materializes through `dataset.to_proto()` instead of re-reading the input path. Equivalent today, but `parquet.load_dataset` takes its scalars from the footer, so an assignment made to the view — as the streaming branch does with `assign_dataset_id` — would be silently dropped. `to_proto` carries them, and saves reopening the file.
- Requires `ord-schema>=0.8.3`; `uv.lock` updated.

## Testing

- `uv sync --group dev --locked` then the full CI sequence against the **released** ord-schema 0.8.3 (not a local checkout): `ruff check`, `ruff format --check`, `ty check`, and `uv run pytest -n auto` — 52 passed.

## Notes

- This is the only call site in this repository affected by the ord-schema API consolidation. I checked for every removed name (`iter_reactions`, `iter_reaction_ids`, `load_reaction`, `num_row_groups`, and the `load_metadata`/`load_footer`/`ParquetFooter`/`streaming_md5` set removed in the follow-up) and this line is the only hit. `parquet.load_dataset` and `parquet.DatasetView`, used elsewhere here, both survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates dataset processing for the ord-schema 0.8.3 `DatasetView` API and preserves view-level scalar assignments during materialization.
- Calls `DatasetView.iter_reaction_ids()` directly.
- Materializes views with `DatasetView.to_proto()`.
- Raises and locks the minimum ord-schema version to 0.8.3.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/process_dataset.py | Adapts reaction-ID iteration to the new DatasetView method and preserves view scalar state when converting to an in-memory proto. |
| pyproject.toml | Raises the pipeline dependency floor to the ord-schema release providing the required DatasetView APIs. |
| uv.lock | Locks ord-schema 0.8.3 and synchronizes the associated dependency metadata and artifact hashes. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Require ord-schema 0.8.3"](https://github.com/open-reaction-database/ord-data/commit/e37195ae54526af9e1fc9e44caf0bd583e64e34b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49930559)</sub>

<!-- /greptile_comment -->